### PR TITLE
fix(mcp): remove structuredContent — Claude Code displays it instead of content[0].text

### DIFF
--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -67,12 +67,6 @@ export function createMcpServer({
               : '';
             return {
               content: [{ type: 'text', text: fm + baseMd }],
-              structuredContent: {
-                source: cached.source,
-                share_id: cached.share_id || null,
-                quality: q,
-                cached: true,
-              },
             };
           }
         }
@@ -105,7 +99,6 @@ export function createMcpServer({
           : '';
         return {
           content: [{ type: 'text', text: fm + baseMd }],
-          structuredContent: { source: 'reddit', share_id: shareId, quality: q, cached: false },
         };
       }
 
@@ -125,12 +118,6 @@ export function createMcpServer({
         : '';
       return {
         content: [{ type: 'text', text: fm + result.markdown }],
-        structuredContent: {
-          source: result.source,
-          share_id: shareId,
-          quality: result.metadata?.quality ?? null,
-          cached: false,
-        },
       };
     }
   );
@@ -200,12 +187,6 @@ export function createMcpServer({
 
       return {
         content: [{ type: 'text', text: markdown }],
-        structuredContent: {
-          url: entry.url,
-          source: entry.source,
-          refreshed,
-          age_ms: ageMs,
-        },
       };
     }
   );
@@ -238,7 +219,6 @@ export function createMcpServer({
       }));
       return {
         content: [{ type: 'text', text: JSON.stringify(items, null, 2) }],
-        structuredContent: { items },
       };
     }
   );

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -452,7 +452,7 @@ describe('POST /mcp', () => {
     assert.equal(res.status, 200);
     const j = parseSse(res.body);
     assert.ok(j.result.content[0].text.includes('# Test page'));
-    assert.equal(j.result.structuredContent.source, 'readability');
+    assert.equal(j.result.structuredContent, undefined, 'structuredContent must be absent so MCP clients surface content[0].text');
   });
 });
 


### PR DESCRIPTION
## Problem

When `read_url`, `get_share`, and `list_recent` return both `content` and `structuredContent`, Claude Code (and likely other MCP clients) displays `structuredContent` as the tool result instead of `content[0].text`. Users see only the metadata JSON object rather than the extracted markdown.

Fixes #1. Bug also reported upstream at https://github.com/anthropics/claude-code/issues/54450.

## Fix

Removes `structuredContent` from all five tool return paths in `lib/mcp.js`. Every tool now returns only `{ content: [{ type: "text", text: "..." }] }`, which all tested MCP clients render correctly.

## Testing

Tested with Claude Code CLI v2.1.121 via a self-hosted instance behind Cloudflare Tunnel. Before: tools displayed `{"source":"readability","share_id":"...","quality":1,"cached":false}`. After: full markdown renders as expected.

---
Co-authored-by: Circe (Claude Code Sonnet 4.6) <circe@athena-council.org>
Co-authored-by: Seneca (Claude Code Sonnet 4.6) <seneca@athena-council.org>