### PR TITLE
feat(pwa): persist frontmatter, comments, depth in localStorage (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.1.0 — 2026-05-05
+
+### Added
+- PWA: persist frontmatter toggle, comments toggle and comment depth across reloads via `localStorage` (keys `pullmd-frontmatter`, `pullmd-comments`, `pullmd-comment-depth`). Closes #20.
+
 ## v2.0.0 — 2026-XX-XX
 
 **Breaking:** PullMD now supports an authentication system. Existing installs keep working unchanged (default `PULLMD_AUTH_MODE=disabled`); operators who want auth must follow [`MIGRATION.md`](./MIGRATION.md).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pullmd",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "main": "server.js",
   "license": "AGPL-3.0-or-later",

--- a/public/index.html
+++ b/public/index.html
@@ -1455,6 +1455,29 @@
         }
       }
 
+      (function restorePwaControls() {
+        try {
+          var v = localStorage.getItem('pullmd-comments');
+          if (v !== null) commentsToggle.checked = v === 'true';
+          v = localStorage.getItem('pullmd-frontmatter');
+          if (v !== null) frontmatterToggle.checked = v === 'true';
+          v = localStorage.getItem('pullmd-comment-depth');
+          if (v !== null) {
+            var n = parseInt(v, 10);
+            if (n >= 1 && n <= 10) depthInput.value = String(n);
+          }
+        } catch (e) {}
+      })();
+      commentsToggle.addEventListener('change', function () {
+        try { localStorage.setItem('pullmd-comments', String(commentsToggle.checked)); } catch (e) {}
+      });
+      frontmatterToggle.addEventListener('change', function () {
+        try { localStorage.setItem('pullmd-frontmatter', String(frontmatterToggle.checked)); } catch (e) {}
+      });
+      depthInput.addEventListener('change', function () {
+        try { localStorage.setItem('pullmd-comment-depth', depthInput.value); } catch (e) {}
+      });
+
       function updateDepthVisibility() {
         depthLabel.style.display = commentsToggle.checked ? '' : 'none';
       }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'pullmd-v18';
+const CACHE_NAME = 'pullmd-v19';
 const SHELL_URLS = ['/', '/index.html', '/manifest.json'];
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- Persists `#frontmatter-toggle`, `#comments-toggle`, and `#depth-input` across reloads via `localStorage`.
- Keys: `pullmd-frontmatter`, `pullmd-comments`, `pullmd-comment-depth` — follows the existing `pullmd-lang` / `pullmd-theme` pattern.
- Restore happens before the first `updateDepthVisibility()` call so the depth label correctly hides when a persisted unchecked comments-toggle is restored.
- Depth value is clamped to the existing `[1, 10]` HTML range; invalid stored values are ignored and the HTML default (`3`) is kept.

Bumps version `2.0.0` → `2.1.0` and SW cache `v18` → `v19`.

Closes #20.

## Test plan
- [x] `node --test` — all 399 tests pass
- [x] Load PWA, toggle frontmatter on, set depth to 5, reload — both states restored
- [x] Toggle comments off, reload — depth label correctly hidden after restore
- [x] Verify comments-toggle persistence works (was not previously persisted)

> Note: do not push `:latest` to v2.x yet — release as `:2.1.0` / `:2.1` / `:2` only. `:latest` stays on v1.2.x per the v2.0 changelog policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)