### PR TITLE
90-day sliding sessions + login redirect with share-target preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Self-hosters should consult [`MIGRATION.md`](./MIGRATION.md) when upgrading acro
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Sessions no longer die a hard 7 days after login regardless of activity** ([#26](https://github.com/AeternaLabsHQ/pullmd/issues/26)). The session cookie is now re-issued with a fresh `Max-Age` whenever the DB-side sliding expiry bumps (existing once-per-minute throttle), so browser cookie and DB session finally slide together.
+
+### Changed
+- **Session TTL raised from 7 to 90 days** (sliding). Anyone active at least once every 90 days stays logged in.
+- **Expired session in the PWA now redirects to the login page** instead of showing a bare "Authentication required" error; the requested URL is carried through `/login?next=` and the conversion resumes automatically after login ([#26](https://github.com/AeternaLabsHQ/pullmd/issues/26)).
+- **`GET /share` is now auth-gated.** Share intents from a logged-out device go straight to the login page and return to the shared URL after login — no more lost share-target URLs. Instances with `PULLMD_AUTH_MODE=disabled` are unaffected ([#26](https://github.com/AeternaLabsHQ/pullmd/issues/26)).
+
+---
+
 ## [2.4.1] - 2026-05-13
 
 ### Fixed

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -32,7 +32,7 @@ export async function verifyPassword(hash, password) {
   }
 }
 
-const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const SESSION_TTL_MS = 90 * 24 * 60 * 60 * 1000;
 const SESSION_SLIDE_MIN_MS = 60 * 1000; // bump expiry at most once per minute
 
 function isoFromMs(ms) {
@@ -152,21 +152,30 @@ export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLo
     return { token, expiresAt };
   }
 
-  function lookupSession(token) {
-    if (!token || typeof token !== 'string') return null;
+  // Internal: like lookupSession, but also reports whether the sliding
+  // expiry was bumped — the middleware uses this to re-issue the cookie
+  // with a fresh Max-Age so browser cookie and DB session slide together.
+  function lookupSessionEx(token) {
+    if (!token || typeof token !== 'string') return { user: null, bumped: false };
     const row = stmts.findSession.get(token);
-    if (!row) return null;
+    if (!row) return { user: null, bumped: false };
 
     // Sliding expiry: if the session has been bumped within the last minute,
     // don't bump again. This avoids a write per request while keeping active
     // users logged in indefinitely.
+    let bumped = false;
     const expiresMs = new Date(row.expires_at + 'Z').getTime();
     const remaining = expiresMs - Date.now();
     if (SESSION_TTL_MS - remaining > SESSION_SLIDE_MIN_MS) {
       stmts.bumpSession.run(isoFromMs(Date.now() + SESSION_TTL_MS), token);
+      bumped = true;
     }
 
-    return { id: row.uid, email: row.email, is_admin: !!row.is_admin };
+    return { user: { id: row.uid, email: row.email, is_admin: !!row.is_admin }, bumped };
+  }
+
+  function lookupSession(token) {
+    return lookupSessionEx(token).user;
   }
 
   function deleteSession(token) {
@@ -354,7 +363,7 @@ export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLo
   }
 
   function middleware() {
-    return (req, _res, next) => {
+    return (req, res, next) => {
       if (mode === 'disabled') {
         req.user = null;
         return next();
@@ -362,8 +371,15 @@ export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLo
 
       const sessionToken = parseCookie(req.headers.cookie, 'pullmd_session');
       if (sessionToken) {
-        const u = lookupSession(sessionToken);
-        if (u) { req.user = u; return next(); }
+        const { user: u, bumped } = lookupSessionEx(sessionToken);
+        if (u) {
+          req.user = u;
+          // Keep the browser cookie's Max-Age in sync with the DB-side sliding
+          // expiry — otherwise the cookie dies a fixed TTL after login no
+          // matter how active the user is.
+          if (bumped) setSessionCookie(res, sessionToken, isSecureRequest(req));
+          return next();
+        }
       }
 
       const bearer = parseBearer(req.headers.authorization);
@@ -424,7 +440,7 @@ export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLo
       'HttpOnly',
       'SameSite=Lax',
       'Path=/',
-      'Max-Age=' + (7 * 24 * 60 * 60),
+      'Max-Age=' + Math.floor(SESSION_TTL_MS / 1000),
     ];
     if (secure) parts.push('Secure');
     res.append('Set-Cookie', parts.join('; '));

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -434,7 +434,21 @@ export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLo
     };
   }
 
+  // Remove any pullmd_session cookie already queued on this response — the
+  // sliding-refresh middleware may have appended one before the route ran.
+  // Dropping it first means the caller's Set-Cookie unambiguously wins,
+  // regardless of header order.
+  function dropQueuedSessionCookie(res) {
+    const existing = res.getHeader('Set-Cookie');
+    if (!existing) return;
+    const rest = (Array.isArray(existing) ? existing : [existing])
+      .filter((c) => !String(c).startsWith('pullmd_session='));
+    res.removeHeader('Set-Cookie');
+    for (const c of rest) res.append('Set-Cookie', c);
+  }
+
   function setSessionCookie(res, token, secure) {
+    dropQueuedSessionCookie(res);
     const parts = [
       `pullmd_session=${token}`,
       'HttpOnly',
@@ -447,6 +461,7 @@ export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLo
   }
 
   function clearSessionCookie(res) {
+    dropQueuedSessionCookie(res);
     res.append('Set-Cookie', 'pullmd_session=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0');
   }
 

--- a/public/index.html
+++ b/public/index.html
@@ -1860,6 +1860,14 @@
             headers: { 'X-Client-Mode': clientMode },
           });
           if (!res.ok) {
+            if (res.status === 401) {
+              // Session expired (or never logged in): bounce through /login and
+              // carry the URL in `next` so the conversion auto-resumes after
+              // login via checkHash(). Also the landing path for mobile share
+              // intents whose session died.
+              location.href = '/login?next=' + encodeURIComponent('/#url=' + encodeURIComponent(url));
+              return;
+            }
             let msg = t('err.unknown', { code: res.status });
             try {
               const body = await res.json();

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'pullmd-v26';
+const CACHE_NAME = 'pullmd-v27';
 const SHELL_URLS = [
   '/',
   '/index.html',

--- a/server.js
+++ b/server.js
@@ -134,7 +134,7 @@ export function createApp(overrides = {}) {
   app.get('/mcp', gate, mcp);
   app.delete('/mcp', gate, mcp);
 
-  app.get('/share', (req, res) => {
+  app.get('/share', gate, (req, res) => {
     let link = req.query.link || req.query.url || '';
     if (!link && req.query.text) {
       const urlMatch = req.query.text.match(/https?:\/\/\S+/);

--- a/test/auth-middleware.test.js
+++ b/test/auth-middleware.test.js
@@ -98,6 +98,8 @@ describe('auth middleware', () => {
       const r = await fetch(base + '/whoami', {
         headers: { Cookie: `pullmd_session=${token}` },
       });
+      // The session was just created, so < SESSION_SLIDE_MIN_MS (1 min) has
+      // elapsed — the bump condition is not met and no refresh cookie is issued.
       assert.equal(r.headers.get('set-cookie'), null);
     });
   });

--- a/test/auth-middleware.test.js
+++ b/test/auth-middleware.test.js
@@ -69,6 +69,39 @@ describe('auth middleware', () => {
     });
   });
 
+  it('multi-user: refreshes the session cookie once past the slide threshold', async () => {
+    const { app, auth, cache } = makeApp('multi-user');
+    await auth.runMigration();
+    const adminId = cache.db.prepare("SELECT id FROM users").get().id;
+    const { token } = auth.createSession(adminId);
+    // Age the session: only 30 of 90 days remain, well past the 1-min slide throttle.
+    cache.db
+      .prepare("UPDATE sessions SET expires_at = datetime('now', '+30 days') WHERE token = ?")
+      .run(token);
+    await withServer(app, async (base) => {
+      const r = await fetch(base + '/whoami', {
+        headers: { Cookie: `pullmd_session=${token}` },
+      });
+      const setCookie = r.headers.get('set-cookie');
+      assert.ok(setCookie, 'expected a refreshed Set-Cookie header');
+      assert.ok(setCookie.includes(`pullmd_session=${token}`), 'must re-issue the same token');
+      assert.match(setCookie, /Max-Age=7776000/); // 90 days in seconds
+    });
+  });
+
+  it('multi-user: does not re-set the cookie for a fresh session', async () => {
+    const { app, auth, cache } = makeApp('multi-user');
+    await auth.runMigration();
+    const adminId = cache.db.prepare("SELECT id FROM users").get().id;
+    const { token } = auth.createSession(adminId);
+    await withServer(app, async (base) => {
+      const r = await fetch(base + '/whoami', {
+        headers: { Cookie: `pullmd_session=${token}` },
+      });
+      assert.equal(r.headers.get('set-cookie'), null);
+    });
+  });
+
   it('multi-user: invalid session cookie leaves req.user null', async () => {
     const { app, auth } = makeApp('multi-user');
     await auth.runMigration();

--- a/test/auth-routes.test.js
+++ b/test/auth-routes.test.js
@@ -82,6 +82,20 @@ describe('auth routes — multi-user', () => {
     });
   });
 
+  it('POST /login honours next=/#url=... (share-restore flow)', async () => {
+    await withApp('multi-user', async (base) => {
+      const next = '/#url=' + encodeURIComponent('https://ex.com/a');
+      const r = await fetch(base + '/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'email=admin@x.y&password=adminpass1&next=' + encodeURIComponent(next),
+        redirect: 'manual',
+      });
+      assert.equal(r.status, 302);
+      assert.equal(r.headers.get('location'), next);
+    });
+  });
+
   it('POST /login refuses next=//evil.com (protocol-relative)', async () => {
     await withApp('multi-user', async (base) => {
       const r = await fetch(base + '/login', {

--- a/test/auth-routes.test.js
+++ b/test/auth-routes.test.js
@@ -148,6 +148,28 @@ describe('auth routes — multi-user', () => {
     });
   });
 
+  it('POST /logout while the session is sliding sends only the clearing cookie', async () => {
+    await withApp('multi-user', async (base, { auth, cache }) => {
+      const adminId = cache.db.prepare("SELECT id FROM users").get().id;
+      const { token } = auth.createSession(adminId);
+      // Age the session so the middleware's sliding refresh fires on this request.
+      cache.db
+        .prepare("UPDATE sessions SET expires_at = datetime('now', '+30 days') WHERE token = ?")
+        .run(token);
+      const r = await fetch(base + '/logout', {
+        method: 'POST',
+        headers: { Cookie: `pullmd_session=${token}` },
+        redirect: 'manual',
+      });
+      assert.equal(r.status, 302);
+      const sessionCookies = (r.headers.getSetCookie?.() || [])
+        .filter((c) => c.startsWith('pullmd_session='));
+      assert.equal(sessionCookies.length, 1, `expected exactly one session Set-Cookie, got: ${sessionCookies.join(' | ')}`);
+      assert.match(sessionCookies[0], /^pullmd_session=;/);
+      assert.match(sessionCookies[0], /Max-Age=0/);
+    });
+  });
+
   it('GET /signup renders form in multi-user mode', async () => {
     await withApp('multi-user', async (base) => {
       const r = await fetch(base + '/signup');

--- a/test/auth-sessions.test.js
+++ b/test/auth-sessions.test.js
@@ -49,15 +49,21 @@ describe('sessions', () => {
     assert.equal(auth.lookupSession(token), null);
   });
 
+  it('createSession sets expiry ~90 days out', () => {
+    const { expiresAt } = auth.createSession(userId);
+    const diffDays = (new Date(expiresAt + 'Z').getTime() - Date.now()) / 86400000;
+    assert.ok(diffDays > 89 && diffDays < 91, `expected ~90 days; got ${diffDays}`);
+  });
+
   it('lookupSession slides expiry on active sessions', () => {
     const { token } = auth.createSession(userId);
     cache.db
-      .prepare("UPDATE sessions SET expires_at = datetime('now', '+6 days') WHERE token = ?")
+      .prepare("UPDATE sessions SET expires_at = datetime('now', '+30 days') WHERE token = ?")
       .run(token);
     auth.lookupSession(token);
     const row = cache.db.prepare("SELECT expires_at FROM sessions WHERE token = ?").get(token);
     const diffSeconds = (new Date(row.expires_at + 'Z').getTime() - Date.now()) / 1000;
-    assert.ok(diffSeconds > 6.5 * 86400, `expected slide past 6.5 days; got ${diffSeconds}s`);
+    assert.ok(diffSeconds > 85 * 86400, `expected slide past 85 days; got ${diffSeconds}s`);
   });
 
   it('createAuth throws on unknown mode', () => {

--- a/test/integration-auth.test.js
+++ b/test/integration-auth.test.js
@@ -140,6 +140,44 @@ describe('integration: auth gating in createApp', () => {
       assert.equal(body.authMisconfigured, true);
     }, { PULLMD_AUTH_TOKEN: 'leftover-v1-token' });
   });
+
+  it('multi-user: /share redirects logged-out browser navigations to /login with next', async () => {
+    await withApp('multi-user', async (base) => {
+      const r = await fetch(base + '/share?link=' + encodeURIComponent('https://ex.com/a'), {
+        redirect: 'manual',
+        headers: { Accept: 'text/html' },
+      });
+      assert.equal(r.status, 302);
+      const loc = r.headers.get('location');
+      assert.ok(loc.startsWith('/login?next='), `unexpected location: ${loc}`);
+      const next = decodeURIComponent(loc.slice('/login?next='.length));
+      assert.equal(next, '/share?link=' + encodeURIComponent('https://ex.com/a'));
+    });
+  });
+
+  it('multi-user: /share with a valid session redirects to /#url=', async () => {
+    await withApp('multi-user', async (base, { auth, cache }) => {
+      const adminId = cache.db.prepare("SELECT id FROM users").get().id;
+      const { token } = auth.createSession(adminId);
+      const r = await fetch(base + '/share?link=' + encodeURIComponent('https://ex.com/a'), {
+        redirect: 'manual',
+        headers: { Accept: 'text/html', Cookie: `pullmd_session=${token}` },
+      });
+      assert.equal(r.status, 302);
+      assert.equal(r.headers.get('location'), '/#url=' + encodeURIComponent('https://ex.com/a'));
+    });
+  });
+
+  it('disabled mode: /share stays open', async () => {
+    await withApp('disabled', async (base) => {
+      const r = await fetch(base + '/share?link=' + encodeURIComponent('https://ex.com/a'), {
+        redirect: 'manual',
+        headers: { Accept: 'text/html' },
+      });
+      assert.equal(r.status, 302);
+      assert.equal(r.headers.get('location'), '/#url=' + encodeURIComponent('https://ex.com/a'));
+    });
+  });
 });
 
 describe('integration: admin-only cache deletion', () => {


### PR DESCRIPTION
Closes #26.

## What

- **`lib/auth.js`** — `SESSION_TTL_MS` raised 7 → 90 days. The session cookie is re-issued with a fresh `Max-Age` whenever the DB-side sliding expiry bumps (same once-per-minute throttle), so browser cookie and DB session slide together. Public `lookupSession()` signature unchanged; the bump signal travels through an internal `lookupSessionEx()`. A new `dropQueuedSessionCookie()` guard strips any middleware-queued refresh cookie before `setSessionCookie`/`clearSessionCookie` append theirs, so logout/re-login can never end up with two competing `Set-Cookie` headers.
- **`public/index.html`** — on a 401 from `/api`, the PWA navigates to `/login?next=` + encoded `/#url=<url>`; after login `checkHash()` picks the URL up and the conversion resumes automatically. The SSE path needs no change: EventSource cannot read status codes and already falls back to the plain fetch, where the redirect fires. SW `CACHE_NAME` bumped to v27.
- **`server.js`** — `GET /share` now goes through the existing `gate` (`requireAuth()`), so logged-out share intents land directly on the login page with `next=/share?link=...` instead of flashing an error in the PWA. Pass-through when auth is disabled.

## Security

No new redirect machinery — every redirect target flows through the existing `safeRedirectPath()` same-origin validation (rejects `//host`, backslash variants, absolute URLs). A regression-guard test pins the `/#url=...` shape the frontend depends on, and the full mobile flow (share intent → login → resume) was traced hop by hop in review.

## Tests

- ~90-day session expiry + sliding past the throttle
- Cookie re-issued past the slide threshold; not re-issued for fresh sessions (no Set-Cookie spam)
- Logout while the session is sliding sends exactly one (clearing) session cookie
- `/share`: logged-out browser navigation → `/login?next=...`; with session → `/#url=...`; auth-disabled unaffected
- `POST /login` with `next=/#url=...` redirects exactly there

Full suite: 566 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
