### PR TITLE
fix(youtube): distinguish transient 429 from a missing transcript

### DIFF
--- a/lib/markitdown-client.js
+++ b/lib/markitdown-client.js
@@ -80,7 +80,7 @@ export async function convertYoutubeViaSidecar(html, opts = {}) {
     if (!res.ok) return null;
     const data = await res.json();
     if (!data || typeof data.markdown !== 'string') return null;
-    return { markdown: data.markdown, title: data.title || null, fields: data.fields || {} };
+    return { markdown: data.markdown, title: data.title || null, fields: data.fields || {}, transcriptStatus: data.transcript_status || null };
   } catch {
     return null;
   } finally {

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -154,7 +154,7 @@ export function createMcpServer({
         ...(yt_chunk !== undefined && { ytChunk: yt_chunk }),
       });
       let shareId = null;
-      if (cache) {
+      if (cache && !result.noStore) {
         shareId = cache.put({
           url,
           title: result.title,
@@ -239,18 +239,25 @@ export function createMcpServer({
             refreshed = true;
           } else {
             const result = await extractWeb(entry.url, { comments: false });
-            cache.put({
-              url: entry.url,
-              title: result.title,
-              markdown: result.markdown,
-              source: result.source,
-              client: 'api',
-              user_id: user?.id ?? null,
-              metadata: result.metadata,
-            });
-            markdown = result.markdown;
-            source = result.source;
-            refreshed = true;
+            // Transient failure (e.g. YouTube 429): keep the existing good
+            // snapshot rather than overwriting it with a placeholder.
+            if (result.noStore) {
+              markdown = entry.markdown;
+              source = entry.source;
+            } else {
+              cache.put({
+                url: entry.url,
+                title: result.title,
+                markdown: result.markdown,
+                source: result.source,
+                client: 'api',
+                user_id: user?.id ?? null,
+                metadata: result.metadata,
+              });
+              markdown = result.markdown;
+              source = result.source;
+              refreshed = true;
+            }
           }
         } catch (err) {
           // Fall through with stale snapshot.

--- a/lib/web.js
+++ b/lib/web.js
@@ -639,7 +639,14 @@ export async function extractWeb(url, options = {}) {
       metadata.ytDuration = f.duration || null;
       metadata.ytViews = f.views || null;
       const markdown = formatHeader(title, url, null) + trimmedMd;
-      return { markdown, title, source: 'youtube', metadata };
+      const result = { markdown, title, source: 'youtube', metadata };
+      // Transient transcript failures (YouTube 429 / fetch error) must not be
+      // cached as if they were the final answer — flag for the caller to skip
+      // persistence so a later retry can pick up the now-available transcript.
+      if (yt.transcriptStatus === 'blocked' || yt.transcriptStatus === 'error') {
+        result.noStore = true;
+      }
+      return result;
     }
     // sidecar down → fall through to the normal HTML extraction below
   }

--- a/markitdown-sidecar/app.py
+++ b/markitdown-sidecar/app.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, Request, HTTPException
 from markitdown import MarkItDown, StreamInfo
 
 from limits import run_guarded
+from yt_transcript import fetch_snippets, _format_transcript
 
 MAX_BODY_BYTES = 50 * 1024 * 1024  # 50 MB
 
@@ -62,65 +63,12 @@ def _yt_api():
 
 
 def _fetch_snippets(video_id):
-    """List of (start_seconds, text). [] on any failure (never raises)."""
+    """List of (start_seconds, text), status. [] on any failure (never raises)."""
     try:
         api = _yt_api()
-
-        def to_list(ft):
-            return [(float(s.start), s.text) for s in ft]
-
-        if YT_LANGS:
-            try:
-                return to_list(api.fetch(video_id, languages=YT_LANGS))
-            except Exception:
-                pass
-        for t in api.list(video_id):
-            try:
-                return to_list(t.fetch())
-            except Exception:
-                continue
     except Exception:
-        pass
-    return []
-
-
-def _fmt_ts(seconds):
-    s = int(seconds)
-    h, rem = divmod(s, 3600)
-    m, sec = divmod(rem, 60)
-    return f"{h}:{m:02d}:{sec:02d}" if h else f"{m:02d}:{sec:02d}"
-
-
-def _format_transcript(snippets, video_id, timecodes, chunk):
-    if not snippets:
-        return ""
-    blocks = []
-    if chunk <= 0:
-        blocks = list(snippets)
-    else:
-        start, texts = None, []
-        for st, tx in snippets:
-            if start is not None and st - start >= chunk:
-                blocks.append((start, " ".join(texts)))
-                start, texts = None, []
-            if start is None:
-                start = st
-            texts.append(tx)
-        if texts:
-            blocks.append((start or 0, " ".join(texts)))
-
-    lines = []
-    for st, tx in blocks:
-        tx = " ".join(tx.split())
-        if not tx:
-            continue
-        if timecodes == "none":
-            lines.append(tx)
-        elif timecodes == "plain":
-            lines.append(f"[{_fmt_ts(st)}] {tx}")
-        else:  # links
-            lines.append(f"[{_fmt_ts(st)}](https://www.youtube.com/watch?v={video_id}&t={int(st)}s) {tx}")
-    return "\n\n".join(lines)
+        return [], "error"
+    return fetch_snippets(api, video_id, YT_LANGS)
 
 
 def _yt_metadata(body):
@@ -221,17 +169,34 @@ async def youtube(request: Request):
         chunk = YT_CHUNK_DEFAULT
 
     meta = _yt_metadata(body)
-    snippets = _fetch_snippets(video_id)
+    snippets, status = _fetch_snippets(video_id)
     transcript = _format_transcript(snippets, video_id, timecodes, chunk)
+
+    if transcript:
+        transcript_md = f"## Transcript\n\n{transcript}\n"
+    elif status == "blocked":
+        # A transcript exists but YouTube rate-limited the content fetch (HTTP 429).
+        # Be honest instead of claiming none exists, and let the caller skip caching
+        # so a later retry can succeed once the rate-limit window clears.
+        transcript_md = (
+            "## Transcript\n\n_A transcript exists for this video but could not be "
+            "retrieved right now: YouTube rate-limited the request (HTTP 429). "
+            "Please try again later._\n"
+        )
+    elif status == "error":
+        transcript_md = "## Transcript\n\n_Transcript could not be retrieved._\n"
+    else:  # none
+        transcript_md = "## Transcript\n\n_No transcript available._\n"
 
     markdown_body = ""
     if meta["description"]:
         markdown_body += f"## Description\n\n{meta['description']}\n\n"
-    markdown_body += f"## Transcript\n\n{transcript}\n" if transcript else "## Transcript\n\n_No transcript available._\n"
+    markdown_body += transcript_md
 
     return {
         "markdown": markdown_body.strip(),
         "title": meta["title"] or "YouTube video",
+        "transcript_status": status,
         "fields": {
             "channel": meta["channel"],
             "duration": _humanize_iso_duration(meta["duration"]),

--- a/markitdown-sidecar/test_youtube.py
+++ b/markitdown-sidecar/test_youtube.py
@@ -1,0 +1,126 @@
+"""Standalone tests for YouTube transcript fetching + classification.
+
+No pytest / youtube_transcript_api / markitdown dependency — run directly:
+    python3 test_youtube.py
+Exits non-zero on the first failed assertion.
+"""
+from yt_transcript import fetch_snippets, _format_transcript
+
+
+# --- fake youtube_transcript_api exceptions (classified by class __name__) ---
+class IpBlocked(Exception):
+    pass
+
+
+class RequestBlocked(Exception):
+    pass
+
+
+class TranscriptsDisabled(Exception):
+    pass
+
+
+class NoTranscriptFound(Exception):
+    pass
+
+
+class _Snippet:
+    def __init__(self, start, text):
+        self.start = start
+        self.text = text
+
+
+class _Transcript:
+    def __init__(self, snippets=None, lang="en", exc=None):
+        self._snippets = snippets or []
+        self.language_code = lang
+        self._exc = exc
+
+    def fetch(self):
+        if self._exc:
+            raise self._exc
+        return self._snippets
+
+
+class _FakeApi:
+    """Configurable stand-in for YouTubeTranscriptApi."""
+
+    def __init__(self, transcripts=None, list_exc=None, fetch_result=None, fetch_exc=None):
+        self._transcripts = transcripts if transcripts is not None else []
+        self._list_exc = list_exc
+        self._fetch_result = fetch_result
+        self._fetch_exc = fetch_exc
+
+    def list(self, video_id):
+        if self._list_exc:
+            raise self._list_exc
+        return list(self._transcripts)
+
+    def fetch(self, video_id, languages=None):
+        if self._fetch_exc:
+            raise self._fetch_exc
+        return self._fetch_result or []
+
+
+def test_ok_returns_snippets_via_list_loop():
+    t = _Transcript(snippets=[_Snippet(0.0, "hello"), _Snippet(2.0, "world")], lang="de")
+    snippets, status = fetch_snippets(_FakeApi(transcripts=[t]), "vid", [])
+    assert status == "ok", status
+    assert snippets == [(0.0, "hello"), (2.0, "world")], snippets
+
+
+def test_list_loop_fetch_429_is_blocked_not_none():
+    # transcript EXISTS (list works) but the content fetch is rate-limited (429)
+    t = _Transcript(exc=IpBlocked("429"), lang="de")
+    snippets, status = fetch_snippets(_FakeApi(transcripts=[t]), "vid", [])
+    assert snippets == [], snippets
+    assert status == "blocked", status
+
+
+def test_list_call_blocked_is_blocked():
+    _, status = fetch_snippets(_FakeApi(list_exc=RequestBlocked("blocked")), "vid", [])
+    assert status == "blocked", status
+
+
+def test_transcripts_disabled_is_none():
+    _, status = fetch_snippets(_FakeApi(list_exc=TranscriptsDisabled("no captions")), "vid", [])
+    assert status == "none", status
+
+
+def test_empty_list_is_none():
+    _, status = fetch_snippets(_FakeApi(transcripts=[]), "vid", [])
+    assert status == "none", status
+
+
+def test_preferred_lang_ok():
+    api = _FakeApi(fetch_result=[_Snippet(1.0, "x")])
+    snippets, status = fetch_snippets(api, "vid", ["en"])
+    assert status == "ok", status
+    assert snippets == [(1.0, "x")], snippets
+
+
+def test_preferred_lang_block_short_circuits():
+    _, status = fetch_snippets(_FakeApi(fetch_exc=IpBlocked("429")), "vid", ["en"])
+    assert status == "blocked", status
+
+
+def test_preferred_lang_miss_falls_through_to_list():
+    # requested 'en' not directly available, but German exists in the list -> ok
+    t = _Transcript(snippets=[_Snippet(0.0, "hallo")], lang="de")
+    api = _FakeApi(transcripts=[t], fetch_exc=NoTranscriptFound("no en"))
+    snippets, status = fetch_snippets(api, "vid", ["en"])
+    assert status == "ok", status
+    assert snippets == [(0.0, "hallo")], snippets
+
+
+def test_format_transcript_none_timecodes_per_snippet():
+    out = _format_transcript([(0.0, "a"), (65.0, "b")], "vid", "none", 0)
+    assert out == "a\n\nb", out
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for t in tests:
+        t()
+        print(f"ok - {t.__name__}")
+    print(f"\n{len(tests)} passed")

--- a/markitdown-sidecar/yt_transcript.py
+++ b/markitdown-sidecar/yt_transcript.py
@@ -1,0 +1,119 @@
+"""YouTube transcript fetching, classification and formatting.
+
+Kept dependency-free (stdlib only) so it is unit-testable without the heavy
+markitdown/fastapi/youtube_transcript_api stack — the API client is injected.
+
+`fetch_snippets` distinguishes *why* a transcript is empty so the caller can tell
+an honest story instead of always claiming "no transcript available":
+
+    ok      -> snippets were retrieved
+    none    -> the video genuinely has no (accessible) transcript
+    blocked -> a transcript EXISTS but YouTube rate-limited the fetch (HTTP 429)
+    error   -> some other failure while fetching
+"""
+
+# Exception class names (matched by __name__ to stay version-resilient) that mean
+# "YouTube rate-limited / blocked us" — youtube_transcript_api raises these on 429.
+_BLOCK_NAMES = {"IpBlocked", "RequestBlocked"}
+
+# Names that mean the video genuinely has no retrievable transcript.
+_NONE_NAMES = {
+    "TranscriptsDisabled",
+    "NoTranscriptFound",
+    "VideoUnavailable",
+    "AgeRestricted",
+    "VideoUnplayable",
+    "InvalidVideoId",
+}
+
+
+def _is_block(exc):
+    """True if the exception represents a YouTube rate-limit / block (HTTP 429)."""
+    if type(exc).__name__ in _BLOCK_NAMES:
+        return True
+    # YouTubeRequestFailed wraps the raw HTTPError; sniff for a 429 in its text.
+    return "429" in str(exc)
+
+
+def _classify_other(exc):
+    return "none" if type(exc).__name__ in _NONE_NAMES else "error"
+
+
+def fetch_snippets(api, video_id, yt_langs):
+    """Return (list_of_(start_seconds, text), status). Never raises.
+
+    `api` is a ready youtube_transcript_api client (injected for testability).
+    `yt_langs` is the preferred language list (may be empty).
+    """
+    def to_list(ft):
+        return [(float(s.start), s.text) for s in ft]
+
+    try:
+        # Preferred languages first, if configured.
+        if yt_langs:
+            try:
+                return to_list(api.fetch(video_id, languages=yt_langs)), "ok"
+            except Exception as e:
+                if _is_block(e):
+                    return [], "blocked"
+                # otherwise fall through to listing every available transcript
+
+        try:
+            transcripts = list(api.list(video_id))
+        except Exception as e:
+            return [], ("blocked" if _is_block(e) else _classify_other(e))
+
+        if not transcripts:
+            return [], "none"
+
+        blocked = False
+        for t in transcripts:
+            try:
+                return to_list(t.fetch()), "ok"
+            except Exception as e:
+                if _is_block(e):
+                    blocked = True
+                # try the next listed transcript
+        # The list call worked (so a transcript exists) but no fetch succeeded.
+        return [], ("blocked" if blocked else "error")
+    except Exception:
+        return [], "error"
+
+
+def _fmt_ts(seconds):
+    s = int(seconds)
+    h, rem = divmod(s, 3600)
+    m, sec = divmod(rem, 60)
+    return f"{h}:{m:02d}:{sec:02d}" if h else f"{m:02d}:{sec:02d}"
+
+
+def _format_transcript(snippets, video_id, timecodes, chunk):
+    if not snippets:
+        return ""
+    blocks = []
+    if chunk <= 0:
+        blocks = list(snippets)
+    else:
+        start, texts = None, []
+        for st, tx in snippets:
+            if start is not None and st - start >= chunk:
+                blocks.append((start, " ".join(texts)))
+                start, texts = None, []
+            if start is None:
+                start = st
+            texts.append(tx)
+        if texts:
+            blocks.append((start or 0, " ".join(texts)))
+
+    lines = []
+    for st, tx in blocks:
+        tx = " ".join(tx.split())
+        if not tx:
+            continue
+        if timecodes == "none":
+            lines.append(tx)
+        elif timecodes == "plain":
+            lines.append(f"[{_fmt_ts(st)}] {tx}")
+        else:  # links
+            lines.append(f"[{_fmt_ts(st)}](https://www.youtube.com/watch?v={video_id}&t={int(st)}s) {tx}")
+    return "\n\n".join(lines)

--- a/server.js
+++ b/server.js
@@ -212,6 +212,9 @@ export function createApp(overrides = {}) {
       return baseMd;
     }
     const result = await extractWebFn(entry.url, { comments: false });
+    // Transient failure (e.g. YouTube 429): keep the existing good snapshot
+    // instead of overwriting it with a "couldn't retrieve" placeholder.
+    if (result.noStore) return entry.markdown;
     cache.put({
       url: entry.url,
       title: result.title,
@@ -470,7 +473,7 @@ export function createApp(overrides = {}) {
       });
 
       let shareId = null;
-      if (cache) {
+      if (cache && !result.noStore) {
         shareId = cache.put({ url, title: result.title, markdown: result.markdown, source: result.source, client, user_id: req.user?.id ?? null, metadata: result.metadata });
       }
 
@@ -801,7 +804,7 @@ export function createApp(overrides = {}) {
       });
 
       let shareId = null;
-      if (cache) {
+      if (cache && !result.noStore) {
         shareId = cache.put({ url, title: result.title, markdown: result.markdown, source: result.source, client, user_id: req.user?.id ?? null, metadata: result.metadata });
       }
 

--- a/test/markitdown-client.test.js
+++ b/test/markitdown-client.test.js
@@ -80,6 +80,14 @@ describe('convertYoutubeViaSidecar', () => {
     assert.equal(cap.o.headers['X-YT-Chunk'], '0');
   });
 
+  it('passes transcript_status through as transcriptStatus', async () => {
+    const out = await convertYoutubeViaSidecar('<html>', {
+      url: 'http://m/convert', sourceUrl: 'https://www.youtube.com/watch?v=x',
+      fetch: async () => okResp({ markdown: '## Transcript\n\n_x_', title: 'V', fields: {}, transcript_status: 'blocked' }),
+    });
+    assert.equal(out.transcriptStatus, 'blocked');
+  });
+
   it('omits format headers when not given', async () => {
     let cap;
     await convertYoutubeViaSidecar('<html>', {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -161,6 +161,28 @@ describe('GET /api - web URLs', () => {
     assert.match(r2.body, /views: 1000/, 'cached serve must include views');
   });
 
+  it('does NOT cache a noStore result (transient 429) — re-extracts on each request', async () => {
+    let calls = 0;
+    const cache = createCache(':memory:');
+    const app = createApp({
+      extractWeb: async () => {
+        calls++;
+        return {
+          markdown: '# Vid\n\n## Transcript\n\n_blocked_',
+          title: 'Vid',
+          source: 'youtube',
+          noStore: true,
+          metadata: { sourceUrl: 'https://youtu.be/blocked', quality: 0.4 },
+        };
+      },
+      cache,
+    });
+    const r1 = await request(app, '/api?url=https://youtu.be/blocked');
+    await request(app, '/api?url=https://youtu.be/blocked');
+    assert.equal(calls, 2, 'noStore result must not be cached; each request must re-extract');
+    assert.equal(r1.headers['x-share-id'], undefined, 'no share id when the result is not stored');
+  });
+
   it('forwards ?extractor= to extractWeb when valid (#17)', async () => {
     let received;
     const app = createApp({

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -872,6 +872,42 @@ describe('extractWeb - YouTube routing', () => {
     if (prev === undefined) delete process.env.MARKITDOWN_YOUTUBE; else process.env.MARKITDOWN_YOUTUBE = prev;
   });
 
+  it('flags the result noStore when the transcript fetch was blocked (transient 429)', async () => {
+    const prev = process.env.MARKITDOWN_YOUTUBE; process.env.MARKITDOWN_YOUTUBE = 'true';
+    const result = await extractWeb('https://www.youtube.com/watch?v=abc123', {
+      fetch: ytFetch(),
+      youtubeClient: async () => ({ markdown: '## Transcript\n\n_blocked_', title: 'V', fields: {}, transcriptStatus: 'blocked' }),
+    });
+    assert.equal(result.source, 'youtube');
+    assert.equal(result.noStore, true, 'a transient block must not be cached');
+    if (prev === undefined) delete process.env.MARKITDOWN_YOUTUBE; else process.env.MARKITDOWN_YOUTUBE = prev;
+  });
+
+  it('flags the result noStore when the transcript fetch errored', async () => {
+    const prev = process.env.MARKITDOWN_YOUTUBE; process.env.MARKITDOWN_YOUTUBE = 'true';
+    const result = await extractWeb('https://www.youtube.com/watch?v=abc123', {
+      fetch: ytFetch(),
+      youtubeClient: async () => ({ markdown: '## Transcript\n\n_err_', title: 'V', fields: {}, transcriptStatus: 'error' }),
+    });
+    assert.equal(result.noStore, true);
+    if (prev === undefined) delete process.env.MARKITDOWN_YOUTUBE; else process.env.MARKITDOWN_YOUTUBE = prev;
+  });
+
+  it('does NOT flag noStore for a normal transcript (status ok) or a genuinely absent one (none)', async () => {
+    const prev = process.env.MARKITDOWN_YOUTUBE; process.env.MARKITDOWN_YOUTUBE = 'true';
+    const ok = await extractWeb('https://www.youtube.com/watch?v=abc123', {
+      fetch: ytFetch(),
+      youtubeClient: async () => ({ markdown: '## Transcript\n\nhi', title: 'V', fields: {}, transcriptStatus: 'ok' }),
+    });
+    assert.ok(!ok.noStore, 'a successful transcript must be cacheable');
+    const none = await extractWeb('https://www.youtube.com/watch?v=abc123', {
+      fetch: ytFetch(),
+      youtubeClient: async () => ({ markdown: '## Transcript\n\n_No transcript available._', title: 'V', fields: {}, transcriptStatus: 'none' }),
+    });
+    assert.ok(!none.noStore, 'a genuinely absent transcript is a stable fact and stays cacheable');
+    if (prev === undefined) delete process.env.MARKITDOWN_YOUTUBE; else process.env.MARKITDOWN_YOUTUBE = prev;
+  });
+
   it('falls back to the HTML pipeline when the youtube sidecar is down', async () => {
     const prev = process.env.MARKITDOWN_YOUTUBE; process.env.MARKITDOWN_YOUTUBE = 'true';
     const result = await extractWeb('https://www.youtube.com/watch?v=abc123', { fetch: ytFetch(), youtubeClient: async () => null });


### PR DESCRIPTION
Closes #33.

## Problem

YouTube videos that **have** a transcript were rendered as `_No transcript available._`. The cause is a **transient per-IP HTTP 429** on the `/api/timedtext` content endpoint (anti-bot rate-limit; normal browsing still returns 200, and `api.list()` still sees the transcript). `youtube_transcript_api` raises `IpBlocked` solely on 429, and the sidecar swallowed every exception, so a temporary block was indistinguishable from a genuinely absent transcript — and got cached as the final answer.

## Change

- **New `markitdown-sidecar/yt_transcript.py`** (dependency-free): `fetch_snippets` returns `(snippets, status)` with status `ok | none | blocked | error`, classifying a 429 as `blocked`. `_fmt_ts`/`_format_transcript` moved here verbatim.
- **`app.py`**: honest message on `blocked` ("transcript exists but YouTube rate-limited the request, try again later") instead of `_No transcript available._`; returns `transcript_status`.
- **`lib/markitdown-client.js`**: passes `transcriptStatus` through.
- **`lib/web.js`**: sets `result.noStore = true` on `blocked`/`error`.
- **`server.js` + `lib/mcp.js`**: skip `cache.put` when `noStore`; refresh paths keep the existing good snapshot instead of overwriting it with a placeholder. `none`/`ok` cache normally.

A genuinely absent transcript keeps the old message and stays cacheable. Language selection is unchanged (first listed transcript: DE for German videos, EN for English videos).

## Tests

- **761 JS** (+5: status passthrough, `noStore` on blocked/error, no-`noStore` on ok/none, not-cached at the server layer) — `node --test`.
- **9 Python** (stdlib-only) — `python3 markitdown-sidecar/test_youtube.py`.
- Verified against the real `youtube_transcript_api`: the reported video now classifies as `blocked` (previously masked as "none").

🤖 Generated with [Claude Code](https://claude.com/claude-code)