### PR TITLE
fix(sidecar): bundle yt_transcript.py in the markitdown image

### DIFF
--- a/markitdown-sidecar/Dockerfile
+++ b/markitdown-sidecar/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app.py limits.py .
+COPY app.py limits.py yt_transcript.py .
 
 USER app
 EXPOSE 8003


### PR DESCRIPTION
Hotfix for a deploy regression from #34.

PR #34 added `markitdown-sidecar/yt_transcript.py` (imported by `app.py`), but the sidecar Dockerfile only `COPY`ied `app.py limits.py`. The built image therefore crash-loops with `ModuleNotFoundError: No module named 'yt_transcript'`. (The CI `build` job only builds the image; it doesn't run it, so it stayed green.)

Adds `yt_transcript.py` to the COPY layer. Test files stay out of the image, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)