### PR TITLE
feat(api): expose transcript state via X-Transcript-Status header

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ Response headers worth checking:
                  playwright | markitdown | youtube | pdf-ocr | ...
   X-Quality      0.0-1.0 extraction confidence
   X-Share-Id     8-hex permalink, openable as /s/<id>
+  X-Transcript-Status  youtube only: ok | none | blocked | error
+                 (blocked/error = transient, not cached — retry later)
 
 Reddit URLs are auto-detected (incl. redd.it short links and /s/ shares).
 Hacker News URLs are auto-detected too — items, comment permalinks, and the
@@ -481,6 +483,7 @@ for it.
 - `X-Source` — `reddit` · `cloudflare` · `readability` · `readability-fallback` · `trafilatura` · `playwright` · `markitdown` · `youtube` · `image-caption` · `audio-transcript` · `pdf-ocr`
 - `X-Quality` — `0.0`–`1.0` extraction confidence
 - `X-Share-Id` — the 8-hex permalink id
+- `X-Transcript-Status` — YouTube only: `ok` · `none` · `blocked` · `error`. `blocked` (YouTube rate-limited the transcript fetch, HTTP 429) and `error` are transient and not cached — retry later; `none` means the video genuinely has no transcript
 
 ---
 

--- a/lib/web.js
+++ b/lib/web.js
@@ -640,6 +640,11 @@ export async function extractWeb(url, options = {}) {
       metadata.ytViews = f.views || null;
       const markdown = formatHeader(title, url, null) + trimmedMd;
       const result = { markdown, title, source: 'youtube', metadata };
+      // Surface the transcript state (ok|none|blocked|error) so the HTTP layer
+      // can expose it via the X-Transcript-Status header for programmatic
+      // consumers (e.g. the collector pipeline) that need to tell a transient
+      // 429 block from a genuinely absent transcript.
+      if (yt.transcriptStatus) result.transcriptStatus = yt.transcriptStatus;
       // Transient transcript failures (YouTube 429 / fetch error) must not be
       // cached as if they were the final answer — flag for the caller to skip
       // persistence so a later retry can pick up the now-available transcript.

--- a/server.js
+++ b/server.js
@@ -487,6 +487,7 @@ export function createApp(overrides = {}) {
         : finalMd;
 
       res.set('X-Source', result.source);
+      if (result.transcriptStatus) res.set('X-Transcript-Status', result.transcriptStatus);
       if (result.metadata?.quality !== undefined) {
         res.set('X-Quality', String(result.metadata.quality));
       }
@@ -817,7 +818,7 @@ export function createApp(overrides = {}) {
         ? mergeMediaFrontmatter(finalMd, result.metadata, result.source)
         : finalMd;
 
-      send('result', { markdown: outMd, source: result.source, shareId: shareId || null });
+      send('result', { markdown: outMd, source: result.source, shareId: shareId || null, transcriptStatus: result.transcriptStatus || null });
       if (cache) cache.logExtraction({
         url, source: result.source,
         quality: result.metadata?.quality,

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -161,6 +161,31 @@ describe('GET /api - web URLs', () => {
     assert.match(r2.body, /views: 1000/, 'cached serve must include views');
   });
 
+  it('sets the X-Transcript-Status header from the extraction result', async () => {
+    const app = createApp({
+      extractWeb: async () => ({
+        markdown: '# V\n\n## Transcript\n\n_blocked_',
+        title: 'V',
+        source: 'youtube',
+        transcriptStatus: 'blocked',
+        noStore: true,
+        metadata: { sourceUrl: 'https://youtu.be/x', quality: 0.4 },
+      }),
+      cache: createCache(':memory:'),
+    });
+    const r = await request(app, '/api?url=https://youtu.be/x');
+    assert.equal(r.headers['x-transcript-status'], 'blocked');
+  });
+
+  it('omits X-Transcript-Status when the result has no transcript status', async () => {
+    const app = createApp({
+      extractWeb: async () => ({ markdown: '# Page', title: 'Page', source: 'readability', metadata: {} }),
+      cache: createCache(':memory:'),
+    });
+    const r = await request(app, '/api?url=https://example.com/plain');
+    assert.equal(r.headers['x-transcript-status'], undefined);
+  });
+
   it('does NOT cache a noStore result (transient 429) — re-extracts on each request', async () => {
     let calls = 0;
     const cache = createCache(':memory:');

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -872,6 +872,16 @@ describe('extractWeb - YouTube routing', () => {
     if (prev === undefined) delete process.env.MARKITDOWN_YOUTUBE; else process.env.MARKITDOWN_YOUTUBE = prev;
   });
 
+  it('surfaces the youtube transcriptStatus on the result', async () => {
+    const prev = process.env.MARKITDOWN_YOUTUBE; process.env.MARKITDOWN_YOUTUBE = 'true';
+    const r = await extractWeb('https://www.youtube.com/watch?v=abc123', {
+      fetch: ytFetch(),
+      youtubeClient: async () => ({ markdown: '## Transcript\n\nhi', title: 'V', fields: {}, transcriptStatus: 'ok' }),
+    });
+    assert.equal(r.transcriptStatus, 'ok');
+    if (prev === undefined) delete process.env.MARKITDOWN_YOUTUBE; else process.env.MARKITDOWN_YOUTUBE = prev;
+  });
+
   it('flags the result noStore when the transcript fetch was blocked (transient 429)', async () => {
     const prev = process.env.MARKITDOWN_YOUTUBE; process.env.MARKITDOWN_YOUTUBE = 'true';
     const result = await extractWeb('https://www.youtube.com/watch?v=abc123', {


### PR DESCRIPTION
Closes #36. Follow-up to #33/#34.

## Why
PullMD distinguishes YouTube transcript states internally (`ok | none | blocked | error`) but only conveyed them as English placeholder strings in the response body. Programmatic consumers (notably the **collector** discovery pipeline) had to brittle-string-match to tell a transient 429 block from a genuinely absent transcript.

## What
- `lib/web.js`: surface `yt.transcriptStatus` on the extraction result.
- `server.js`: set **`X-Transcript-Status`** response header on `GET /api`; include `transcriptStatus` in the SSE `result` event.
- Header is only set for sources that carry a status (YouTube); absent otherwise.
- Transient blocks are never cached, so the header is **always present for the actionable `blocked` case** (served fresh).
- README: documented in both header references.

## Consumer semantics
- `ok` → real transcript.
- `blocked` (HTTP 429) / `error` → transient, not cached → skip persisting, retry later.
- `none` → permanent negative.

## Tests
764 JS (+3): result surfaces `transcriptStatus`; `GET /api` sets the header; header omitted for sources without a status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)