### PR TITLE
fix(docker): prevent SQLITE_CANTOPEN crash on first startup (closes #38)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,13 @@ WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
 COPY . .
 
+RUN apk add --no-cache su-exec
+
 RUN mkdir -p /data && chown -R app:app /app /data
 
-USER app
-
+# The entrypoint script runs as root, fixes permissions on bind-mounted
+# volumes that the Docker daemon may have created as root, then drops to
+# the unprivileged app user via su-exec.
 EXPOSE 3000
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,5 @@ RUN mkdir -p /data && chown -R app:app /app /data
 # volumes that the Docker daemon may have created as root, then drops to
 # the unprivileged app user via su-exec.
 EXPOSE 3000
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Fix permissions on bind-mounted volumes that Docker creates as root.
+# The Dockerfile sets correct ownership in the image layer (chown app:app /data),
+# but when ./data doesn't exist on the host, Docker daemon creates it as root
+# and the bind mount obscures the image's permission setup. This runs as root
+# before dropping privileges, so the fix always applies.
+chown -R app:app /data 2>/dev/null || true
+
+# Preserve the node-wrapping logic from the node base image: if the first arg
+# starts with "-" or isn't a known command, prepend "node".
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ] || { [ -f "${1}" ] && ! [ -x "${1}" ]; }; then
+  set -- node "$@"
+fi
+
+# Drop to the unprivileged app user and run the command.
+exec su-exec app:app "$@"


### PR DESCRIPTION
When docker compose up -d is run without a pre-existing ./data directory, the Docker daemon creates it as root. The old Dockerfile used USER app, so the container process (UID=100) could not write to the root-owned bind mount — causing better-sqlite3 to fail with SQLITE_CANTOPEN and the container to restart endlessly.

Replace the static USER app directive with a docker-entrypoint.sh that runs as root, chowns /data to app:app, then drops privileges via su-exec before starting node. This separates privilege-requiring setup from application execution — the same pattern used by official Postgres and Redis images.