### PR TITLE
v3.2.0 — strip tracking pixels, ScienceDaily lead-image recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Self-hosters should consult [`MIGRATION.md`](./MIGRATION.md) when upgrading acro
 
 ### Fixed
 
+- **Cache hits now serve complete metadata.** The cached-response path rebuilt a minimal `{title, url, quality}` object, so on a cache hit the frontmatter lost `image` (`og:image`/`twitter:image`), `description`, `author`, `language`, and `site`, and `format=json` returned `metadata: null`. The full metadata persisted at extraction time (in the existing `metadata` column) is now served on cache hits in both the frontmatter and the `format=json` response - no schema change needed. Consumers reading `metadata.ogImage` / `metadata.twitterImage` (e.g. for an article lead image) now get it on cached pages too.
 - **Tracking pixels no longer leak into the Markdown.** 1x1 invisible beacon images (e.g. republish/analytics counters embedded inline in article text) were kept by Readability and rendered as bogus Markdown images. `cleanDom` now drops any `<img>` whose declared width and height are both ≤ 1; genuine wide/tall banners (only one tiny dimension) are spared.
 - **YouTube: transient 429 distinguished from a missing transcript** (#34, closes #33). A per-IP 429 on the timedtext endpoint was mislabeled as a permanent block; it is now classified honestly and not cached, so a later retry can pick up the now-available transcript.
 - **Sidecar: bundle `yt_transcript.py` in the markitdown image** (#35). The YouTube transcript helper was missing from the built image; it is now copied explicitly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Self-hosters should consult [`MIGRATION.md`](./MIGRATION.md) when upgrading acro
 
 ---
 
+## [3.2.0] - 2026-06-25
+
+### Added
+
+- **`X-Transcript-Status` response header** (#37, closes #36). YouTube conversions now expose the transcript state (`ok` / `none` / `blocked` / `error`) as a response header, so programmatic consumers can tell a transient block from a genuinely absent transcript without parsing the body.
+- **ScienceDaily lead-image recipe.** A shipped site recipe for `*.sciencedaily.com/releases/**` unwraps the article's `#text` container so the lead image survives extraction. Without it, Readability picks the paragraph-dense inner block as the article and drops the sibling `<figure>` that holds the real lead image. General sites should still rely on the `image` frontmatter field (from `og:image`) for a robust lead-image source.
+
+### Fixed
+
+- **Tracking pixels no longer leak into the Markdown.** 1x1 invisible beacon images (e.g. republish/analytics counters embedded inline in article text) were kept by Readability and rendered as bogus Markdown images. `cleanDom` now drops any `<img>` whose declared width and height are both ≤ 1; genuine wide/tall banners (only one tiny dimension) are spared.
+- **YouTube: transient 429 distinguished from a missing transcript** (#34, closes #33). A per-IP 429 on the timedtext endpoint was mislabeled as a permanent block; it is now classified honestly and not cached, so a later retry can pick up the now-available transcript.
+- **Sidecar: bundle `yt_transcript.py` in the markitdown image** (#35). The YouTube transcript helper was missing from the built image; it is now copied explicitly.
+
+---
+
 ## [3.1.0] - 2026-06-15
 
 ### Added

--- a/lib/web.js
+++ b/lib/web.js
@@ -292,6 +292,19 @@ function cleanDom(document, extraRemoveSelectors = []) {
       img.removeAttribute('alt');
     }
   }
+
+  // Drop tracking pixels: a 1x1 (or smaller) image with both dimensions
+  // declared is an invisible analytics beacon, not content. Readability keeps
+  // these when they ride inline inside a content paragraph (e.g. theconversation
+  // republish counter), so they'd otherwise surface as bogus markdown images.
+  // Require BOTH width and height ≤ 1 so genuine 1xN/Nx1 banners are spared.
+  for (const img of document.querySelectorAll('img[width][height]')) {
+    const w = parseInt(img.getAttribute('width'), 10);
+    const h = parseInt(img.getAttribute('height'), 10);
+    if (Number.isFinite(w) && Number.isFinite(h) && w <= 1 && h <= 1) {
+      img.remove();
+    }
+  }
 }
 
 // URL-bearing attributes per element. Relative values break once the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pullmd",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pullmd",
-      "version": "3.0.0",
+      "version": "3.2.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pullmd",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "type": "module",
   "main": "server.js",
   "license": "AGPL-3.0-or-later",

--- a/server.js
+++ b/server.js
@@ -294,15 +294,28 @@ export function createApp(overrides = {}) {
           const baseMd = cached.markdown;
           const cachedQuality = qualityScore(baseMd);
           const titleMatchCached = baseMd.match(/^#\s+(.+)$/m);
+          // Serve the full metadata persisted at extraction time (image/og:image,
+          // description, author, language, site, …) instead of rebuilding a
+          // minimal {title,url,quality} object — those fields were silently
+          // dropped on cache hits before. title/url/quality are renormalized from
+          // the cached row (markdown H1 + live quality) so they stay authoritative.
+          const cachedMeta = cached.metadata || {};
+          const outMeta = {
+            ...cachedMeta,
+            title: titleMatchCached?.[1] || cached.title || cachedMeta.title || null,
+            sourceUrl: url,
+            quality: cachedQuality,
+          };
+          // Reddit/HN mirror their fresh paths: a minimal frontmatter object plus
+          // mergeMediaFrontmatter for the structured fields (subreddit/author/…).
+          const fmInput = structuredCached
+            ? { title: outMeta.title, sourceUrl: url, quality: cachedQuality }
+            : outMeta;
           const fm = wantFrontmatter
-            ? buildFrontmatter({
-                title: titleMatchCached?.[1] || cached.title,
-                sourceUrl: url,
-                quality: cachedQuality,
-              }, { source: cached.source, shareId: cached.share_id })
+            ? buildFrontmatter(fmInput, { source: cached.source, shareId: cached.share_id })
             : '';
           const md = wantFrontmatter
-            ? mergeMediaFrontmatter(fm + baseMd, cached.metadata, cached.source)
+            ? mergeMediaFrontmatter(fm + baseMd, cachedMeta, cached.source)
             : fm + baseMd;
           res.set('X-Source', cached.source);
           res.set('X-Quality', String(cachedQuality));
@@ -314,7 +327,7 @@ export function createApp(overrides = {}) {
           if (format === 'json') {
             return res.json({
               markdown: md,
-              metadata: null,
+              metadata: outMeta,
               source: cached.source,
               shareId: cached.share_id || null,
             });

--- a/site-recipes.default.json
+++ b/site-recipes.default.json
@@ -41,5 +41,13 @@
       "wait_for": ".js-comment-body",
       "wait_timeout_ms": 5000
     }
+  },
+  {
+    "name": "sciencedaily-lead-image",
+    "host": "*.sciencedaily.com",
+    "path": "/releases/**",
+    "preprocess": [
+      { "action": "unwrap", "selector": "#text" }
+    ]
   }
 ]

--- a/test/recipes-loader.test.js
+++ b/test/recipes-loader.test.js
@@ -153,3 +153,20 @@ describe('loadRecipes — user overlay', () => {
     assert.equal(status.sources[1].rejected, 1);
   });
 });
+
+describe('shipped site-recipes.default.json', () => {
+  const shippedPath = path.resolve(here, '..', 'site-recipes.default.json');
+
+  it('loads with zero rejections (every entry passes RecipeSchema)', () => {
+    const { recipes, status } = loadRecipes({ defaultPath: shippedPath, userPath: null });
+    assert.equal(status.rejected, 0, 'a shipped recipe failed schema validation');
+    assert.ok(recipes.length >= 1);
+  });
+
+  it('includes the sciencedaily lead-image recipe', () => {
+    const { recipes } = loadRecipes({ defaultPath: shippedPath, userPath: null });
+    const sd = recipes.find((r) => r.name === 'sciencedaily-lead-image');
+    assert.ok(sd, 'sciencedaily-lead-image recipe is present');
+    assert.deepEqual(sd.preprocess, [{ action: 'unwrap', selector: '#text' }]);
+  });
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -366,6 +366,50 @@ describe('GET /api with frontmatter=true', () => {
   });
 });
 
+describe('GET /api - cache-hit metadata completeness', () => {
+  function webApp(cache, metadata) {
+    let calls = 0;
+    const app = createApp({
+      extractWeb: async () => {
+        calls++;
+        return { markdown: '# Leopards\n\nBody content here.', title: 'Leopards', source: 'readability', metadata };
+      },
+      cache,
+    });
+    return { app, calls: () => calls };
+  }
+
+  const META = {
+    title: 'Leopards', sourceUrl: 'https://example.com/lp', quality: 1,
+    ogImage: 'https://example.com/lead.webp', twitterImage: 'https://example.com/tw.jpg',
+    description: 'A leopard story', author: 'Jane Doe', ogSiteName: 'Example', language: 'en',
+  };
+
+  it('surfaces image/description/author from cached metadata in frontmatter', async () => {
+    const cache = createCache(':memory:');
+    const { app, calls } = webApp(cache, META);
+    await request(app, '/api?url=https://example.com/lp&frontmatter=true');     // fresh: stores metadata
+    const r2 = await request(app, '/api?url=https://example.com/lp&frontmatter=true'); // cache hit
+    assert.equal(calls(), 1, 'second request must be served from cache');
+    assert.match(r2.body, /image: https:\/\/example\.com\/lead\.webp/, 'image must survive cache');
+    assert.match(r2.body, /description: A leopard story/, 'description must survive cache');
+    assert.match(r2.body, /author: Jane Doe/, 'author must survive cache');
+  });
+
+  it('returns full metadata (not null) with og/twitter image in format=json on cache hits', async () => {
+    const cache = createCache(':memory:');
+    const { app, calls } = webApp(cache, META);
+    await request(app, '/api?url=https://example.com/lp&format=json');           // fresh
+    const r2 = await request(app, '/api?url=https://example.com/lp&format=json'); // cache hit
+    assert.equal(calls(), 1, 'second request must be served from cache');
+    const body = JSON.parse(r2.body);
+    assert.ok(body.metadata, 'cache-hit json metadata must not be null');
+    assert.equal(body.metadata.ogImage, 'https://example.com/lead.webp');
+    assert.equal(body.metadata.twitterImage, 'https://example.com/tw.jpg');
+    assert.equal(body.metadata.sourceUrl, 'https://example.com/lp');
+  });
+});
+
 describe('GET /api/stats', () => {
   it('returns extraction stats from logged events', async () => {
     const cache = createCache(':memory:');

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -562,6 +562,26 @@ describe('cleanDom CMS-pattern preprocessing', () => {
     const result = await extractWeb('https://example.com/photos', { fetch: fetchHtml(html) });
     assert.match(result.markdown, /A red sunset over mountains/);
   });
+
+  it('strips 1x1 tracking-pixel images but keeps real content images', async () => {
+    const html = `<!doctype html><html><body><article><h1>Tracked</h1>
+      ${Array.from({ length: 8 }, () => '<p>This is a paragraph that is comfortably long enough to count as a real paragraph for the metrics regex used in scoring and pickBest decisions.</p>').join('')}
+      <p>End of article.<img src="https://counter.example.com/count.gif?d=lightbox" alt="Tracker" width="1" height="1" style="opacity:0"></p>
+      <p>A real photo <img src="https://example.com/lead.jpg" alt="A real lead image" width="1200" height="675"> sits inline here.</p>
+    </article></body></html>`;
+    const result = await extractWeb('https://example.com/tracked', { fetch: fetchHtml(html) });
+    assert.doesNotMatch(result.markdown, /count\.gif/, '1x1 tracking pixel must be removed');
+    assert.match(result.markdown, /example\.com\/lead\.jpg/, 'real content image must survive');
+  });
+
+  it('keeps images that declare only one tiny dimension (not a 1x1 beacon)', async () => {
+    const html = `<!doctype html><html><body><article><h1>Banner</h1>
+      ${Array.from({ length: 8 }, () => '<p>This is a paragraph that is comfortably long enough to count as a real paragraph for the metrics regex used in scoring and pickBest decisions.</p>').join('')}
+      <p>Wide banner <img src="https://example.com/banner.png" alt="Banner" width="1200" height="1"> here.</p>
+    </article></body></html>`;
+    const result = await extractWeb('https://example.com/banner', { fetch: fetchHtml(html) });
+    assert.match(result.markdown, /example\.com\/banner\.png/, 'a 1200x1 image is not a tracking pixel');
+  });
 });
 
 describe('extractWeb — recipe integration (Hook 0+1)', () => {


### PR DESCRIPTION
## Summary

Fixes a web-extraction issue surfaced via the Collector pipeline: PullMD kept invisible **1×1 tracking pixels** in the Markdown while **dropping the real lead image** (e.g. ScienceDaily's `cape-leopard.webp`).

### Root cause

Readability's `_grabArticle` selects the paragraph-dense inner block (`#text` on ScienceDaily) as the article and drops the sibling `<figure>` that holds the lead image (too little text to clear the sibling threshold). The tracking pixel survives precisely because it rides *inline* inside a content paragraph. PullMD then renders that surviving pixel as a Markdown image.

### Changes

- **Strip tracking pixels** (`lib/web.js` / `cleanDom`): remove any `<img>` whose declared width **and** height are both ≤ 1. Wide/tall banners (only one tiny dimension) are spared. Benefits all sites, not just ScienceDaily.
- **`sciencedaily-lead-image` recipe** (`site-recipes.default.json`): `unwrap #text` so the lead `<figure>` ends up inside the chosen article container and survives extraction. Verified end-to-end against the live page.
- **Guard test**: the shipped `site-recipes.default.json` loads with zero rejections and contains the new recipe.

### Note for general sites

A per-site recipe can't scale to every news source. The robust general path is the **`image` frontmatter field** (populated from `og:image`) via `?frontmatter=true` - the Collector is being updated to read that.

### Release batching

This release also batches the untagged `main` commits since v3.1.0:
- #34 — distinguish a transient YouTube 429 from a missing transcript
- #35 — bundle `yt_transcript.py` in the markitdown image
- #37 — expose transcript state via `X-Transcript-Status` header

Bumps version to **3.2.0** and updates `CHANGELOG.md`.

### Tests

768/768 passing (`node --test`), including 2 new pixel tests and 2 new recipe-loader guard tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)