### PR TITLE
feat: coverage guard for page-builder one-pagers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -208,6 +208,12 @@ PULLMD_PDF_OCR_MODEL=
 # all fields are emitted (safe fallback, never a crash).
 # PULLMD_FRONTMATTER_FIELDS=title,url,source,fetched
 
+# Coverage guard: when an extraction covers only a sliver of the page's text and
+# a single container holds nearly all of it, re-convert that container instead.
+# Catches page-builder one-pagers whose chapters sit in flat sibling blocks.
+# Default: on. Set to "off" to disable.
+# PULLMD_COVERAGE_GUARD=off
+
 # --- MarkItDown YouTube tier (opt-in; no API key required) ---
 # Set MARKITDOWN_YOUTUBE=true on the pullmd service to enable YouTube URL routing
 # through the markitdown sidecar (transcript + title + description extraction).

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ All variables go in `.env` (copy from `.env.example`):
 | `PULLMD_AUTH_TOKEN`    | no       | Legacy bearer token compat (single-admin mode only, deprecated).                                    |
 | `PULLMD_SOURCE_HEADER` | no       | Set to `true` to restore the legacy inline source header in the body (`# Title` + `**domain** · date` + url; for Reddit the `**r/sub** · u/user · N ↑` line). Default (unset): clean body - just the H1 title; source/date/post meta live in the frontmatter. |
 | `PULLMD_FRONTMATTER_FIELDS` | no  | Comma-separated allowlist of frontmatter fields to emit (e.g. `title,url,source,llm_tokens`). Unset = all fields. Trims tokens. Unknown names are ignored with a startup warning. |
+| `PULLMD_COVERAGE_GUARD` | no | Set to `off` to disable the coverage guard. Default (unset): on. The guard notices when an extraction kept only a sliver of the page - the failure mode of page-builder one-pagers, whose chapters sit in flat sibling containers that Readability's single-candidate scoring discards - and re-converts the container holding the body instead. It only ever grows the result, records `source: coverage-guard`, and explains itself in `metadata.extractorReason`. |
 
 `PUBLIC_URL` matters for self-hosting: the help page and downloadable
 skill embed it as the canonical endpoint. Set it correctly and your
@@ -684,6 +685,7 @@ To write or contribute a recipe, see the **[site-recipe contributor guide](./SIT
 - `lib/youtube.js` — YouTube URL detection and normalization.
 - `lib/llm/` — provider resolver + adapters for image captioning (vision), audio transcription (STT), and PDF OCR against OpenAI-compatible endpoints.
 - `lib/frontmatter.js` — YAML frontmatter builder with the `PULLMD_FRONTMATTER_FIELDS` allowlist.
+- `lib/coverage-guard.js` — detects extractions that kept only a sliver of the page and recovers the container holding the body.
 - `lib/query-extract.js` — Opt-in query-scoped extraction (`?query=`): BM25 over heading-based sections of the converted markdown, returning only the relevant sections/blocks. Composes `lib/markdown-sections.js` (block/section parser) and `lib/bm25.js` (tokenizer + scorer).
 - `public/` — PWA frontend (vanilla JS, dark/paper themes, service worker, EventSource client for `/api/stream`).
 - `skill/pullmd/` — Claude Code skill source (templated with `__PULLMD_URL__`).

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ Both `query` and `max_tokens` are also available on the MCP `read_url` tool.
 
 ### Response headers
 
-- `X-Source` — `reddit` · `cloudflare` · `readability` · `readability-fallback` · `trafilatura` · `playwright` · `markitdown` · `youtube` · `image-caption` · `audio-transcript` · `pdf-ocr`
+- `X-Source` — `reddit` · `cloudflare` · `readability` · `readability-fallback` · `trafilatura` · `playwright` · `recipe-content` · `coverage-guard` · `markitdown` · `youtube` · `image-caption` · `audio-transcript` · `pdf-ocr`
 - `X-Quality` — `0.0`–`1.0` extraction confidence
 - `X-Share-Id` — the 8-hex permalink id
 - `X-Transcript-Status` — YouTube only: `ok` · `none` · `blocked` · `error`. `blocked` (YouTube rate-limited the transcript fetch, HTTP 429) and `error` are transient and not cached — retry later; `none` means the video genuinely has no transcript

--- a/SITE-RECIPES.md
+++ b/SITE-RECIPES.md
@@ -658,7 +658,7 @@ retry before concluding your recipe is broken.
 **Recipe seems to do nothing?** Check how the page was actually extracted: look
 at the `X-Source` response header (or the `source:` field in the frontmatter,
 with `frontmatter=true`). Recipes only apply when it reads `readability`,
-`readability-fallback`, `trafilatura`, or `playwright`. Any other value —
+`readability-fallback`, `trafilatura`, `playwright`, or `coverage-guard`. Any other value —
 `cloudflare`, `reddit`, `hackernews`, `youtube`, `markitdown`, `pdf-ocr`,
 `image-caption`, `audio-transcript` — means the request never reached the
 recipe layer for the reasons in [§1](#1-when-you-need-a-recipe); your recipe

--- a/SITE-RECIPES.md
+++ b/SITE-RECIPES.md
@@ -545,6 +545,8 @@ readability: …`). A site redesign therefore degrades your recipe to the generi
 behavior instead of breaking the page — but check that field if a recipe
 mysteriously stops taking effect.
 
+> Before writing a `select.content` recipe for a one-pager, check whether the built-in coverage guard already handles it: fetch the page and look at `metadata.extractorReason`. If it starts with `coverage guard:`, the body was recovered automatically and a recipe is only needed for finer cleanup (removing widget chrome, gluing numbering back on).
+
 ---
 
 ## 8. A complete annotated example

--- a/lib/coverage-guard.js
+++ b/lib/coverage-guard.js
@@ -70,13 +70,15 @@ export function findDominantContainer(body) {
   if (!body) return null;
   let node = body;
   for (let depth = 0; depth < GUARD_LIMITS.MAX_DEPTH; depth++) {
-    const literalChildren = Array.from(node.children);
-    if (literalChildren.length !== 1) break; // Stop if branching (2+ children) or no children
-    const child = literalChildren[0];
-    const childLen = textLength(child);
     const parentLen = textLength(node);
-    if (parentLen === 0 || childLen / parentLen < GUARD_LIMITS.DOMINANCE) break;
-    node = child;
+    if (parentLen === 0) break;
+    let best = null;
+    for (const child of node.children) {
+      const len = textLength(child);
+      if (len > 0 && (best === null || len > best.len)) best = { el: child, len };
+    }
+    if (best === null || best.len / parentLen < GUARD_LIMITS.DOMINANCE) break;
+    node = best.el;
   }
   return node === body ? null : node;
 }

--- a/lib/coverage-guard.js
+++ b/lib/coverage-guard.js
@@ -29,6 +29,8 @@ export const GUARD_LIMITS = {
   MIN_PARAGRAPHS: 5,
   // Backstop against pathological markup.
   MAX_DEPTH: 30,
+  // Cap on the page-controlled part of a container label (id / first class).
+  MAX_LABEL: 60,
 };
 
 /**
@@ -97,22 +99,35 @@ export function acceptCandidate(candidateMd, extractLen) {
   return metrics(md).paragraphs >= GUARD_LIMITS.MIN_PARAGRAPHS;
 }
 
-/** Short human-readable handle for a DOM node, for the extractor reason. */
+/**
+ * Short human-readable handle for a DOM node, for the extractor reason.
+ * id and class come from the page, so the label is capped: the reason string is
+ * persisted (frontmatter, extraction log) and must not inherit an unbounded
+ * attribute from whatever was fetched.
+ */
 export function containerLabel(node) {
   const tag = node.tagName.toLowerCase();
-  if (node.id) return `${tag}#${node.id}`;
+  const clip = (s) => (s.length > GUARD_LIMITS.MAX_LABEL ? `${s.slice(0, GUARD_LIMITS.MAX_LABEL)}…` : s);
+  if (node.id) return `${tag}#${clip(String(node.id))}`;
   const cls = String(node.getAttribute('class') || '').trim().split(/\s+/).filter(Boolean)[0];
-  return cls ? `${tag}.${cls}` : tag;
+  return cls ? `${tag}.${clip(cls)}` : tag;
 }
 
 /**
  * The transparency channel: an operator reading metadata.extractorReason must be
  * able to judge afterwards whether the intervention was warranted, so the reason
  * carries the numbers it was based on and the decision it overrode.
+ *
+ * `holds` is the recovered container's share of the body. It is NOT implied by
+ * the trigger: DOMINANCE is checked per descent level, so over several levels
+ * the shares multiply and the container can hold well under DOMINANCE of the
+ * body (each level sheds a sibling ≤10%, usually chrome — but the operator is
+ * the one who gets to judge that, so state the figure rather than assume it).
  */
 export function guardReason(bodyTextLen, extractLen, node, candidateLen, priorReason) {
   const coverage = ((extractLen / bodyTextLen) * 100).toFixed(1);
   const gain = (candidateLen / Math.max(extractLen, 1)).toFixed(1);
+  const holds = bodyTextLen > 0 ? ((textLength(node) / bodyTextLen) * 100).toFixed(0) : '0';
   return `coverage guard: ${coverage}% coverage of ${bodyTextLen}c body, `
-    + `recovered ${containerLabel(node)} (${gain}x); prior pick: ${priorReason}`;
+    + `recovered ${containerLabel(node)} (${gain}x, holds ${holds}% of body); prior pick: ${priorReason}`;
 }

--- a/lib/coverage-guard.js
+++ b/lib/coverage-guard.js
@@ -1,0 +1,113 @@
+/**
+ * Coverage guard: detect extractions that kept only a sliver of the page.
+ *
+ * Readability commits to a single best candidate container. On pages whose body
+ * is one wrapper full of flat sibling blocks — the shape page builders emit for
+ * one-pagers — it keeps one block and silently drops the rest. The output looks
+ * well-formed, so nothing downstream notices.
+ *
+ * The signal is the ratio between the chosen extract and the cleaned body text.
+ * A tiny ratio alone is not enough (listing pages legitimately extract little),
+ * so the guard additionally requires that a single container holds nearly all of
+ * the body text — that is what distinguishes "one article split across siblings"
+ * from "many separate teasers".
+ *
+ * Thresholds are calibrated against an 85-page live corpus; see
+ * docs/superpowers/specs/2026-07-29-coverage-guard-design.md.
+ */
+import { metrics } from './scoring.js';
+
+export const GUARD_LIMITS = {
+  // Below this much cleaned body text a small extract is unremarkable.
+  MIN_BODY_TEXT: 20_000,
+  // Extract / body ratio under which the extraction is treated as suspect.
+  MAX_COVERAGE: 0.10,
+  // Share of its parent's text a child must hold to be descended into.
+  DOMINANCE: 0.90,
+  // How much larger the recovered candidate must be before it is trusted.
+  MIN_GAIN: 3,
+  // Prose floor that separates a real body from nav soup.
+  MIN_PARAGRAPHS: 5,
+  // Backstop against pathological markup.
+  MAX_DEPTH: 30,
+};
+
+/**
+ * The guard is on by default and switched off with PULLMD_COVERAGE_GUARD=off.
+ * Read at call time, not at module load, so operators and tests can toggle it.
+ */
+export function isEnabled() {
+  return String(process.env.PULLMD_COVERAGE_GUARD || '').trim().toLowerCase() !== 'off';
+}
+
+function textLength(el) {
+  if (!el) return 0;
+  return (el.textContent || '').replace(/\s+/g, ' ').trim().length;
+}
+
+/** Visible-text length of the document body, whitespace collapsed. */
+export function bodyTextLength(document) {
+  return textLength(document?.querySelector('body'));
+}
+
+/** Cheap pre-check: is this extraction suspect enough to look for a better one? */
+export function shouldAttempt(bodyTextLen, extractLen) {
+  if (!isEnabled()) return false;
+  if (bodyTextLen < GUARD_LIMITS.MIN_BODY_TEXT) return false;
+  return extractLen / bodyTextLen < GUARD_LIMITS.MAX_COVERAGE;
+}
+
+/**
+ * Descend from the body while a single child holds DOMINANCE of its parent's
+ * text; stop where the text branches out across siblings. That stopping point is
+ * the content root — on a page-builder one-pager it is the wrapper holding every
+ * chapter, which is exactly what a hand-written `select.content` recipe names.
+ *
+ * Returns null when the descent never leaves the body: that means no single
+ * container owns the page, which is the signature of a listing or index page.
+ */
+export function findDominantContainer(body) {
+  if (!body) return null;
+  let node = body;
+  for (let depth = 0; depth < GUARD_LIMITS.MAX_DEPTH; depth++) {
+    const literalChildren = Array.from(node.children);
+    if (literalChildren.length !== 1) break; // Stop if branching (2+ children) or no children
+    const child = literalChildren[0];
+    const childLen = textLength(child);
+    const parentLen = textLength(node);
+    if (parentLen === 0 || childLen / parentLen < GUARD_LIMITS.DOMINANCE) break;
+    node = child;
+  }
+  return node === body ? null : node;
+}
+
+/**
+ * Only take the recovered candidate when it is substantially larger AND reads
+ * like prose. The size floor keeps the guard from swapping in a marginally
+ * different extract; the paragraph floor keeps it from swapping in nav soup.
+ */
+export function acceptCandidate(candidateMd, extractLen) {
+  const md = (candidateMd || '').trim();
+  if (md.length < GUARD_LIMITS.MIN_GAIN * Math.max(extractLen, 1)) return false;
+  return metrics(md).paragraphs >= GUARD_LIMITS.MIN_PARAGRAPHS;
+}
+
+/** Short human-readable handle for a DOM node, for the extractor reason. */
+export function containerLabel(node) {
+  const tag = node.tagName.toLowerCase();
+  if (node.id) return `${tag}#${node.id}`;
+  const cls = String(node.getAttribute('class') || '').trim().split(/\s+/).filter(Boolean)[0];
+  return cls ? `${tag}.${cls}` : tag;
+}
+
+/**
+ * The transparency channel: an operator reading metadata.extractorReason must be
+ * able to judge afterwards whether the intervention was warranted, so the reason
+ * carries the numbers it was based on and the decision it overrode.
+ */
+export function guardReason(bodyTextLen, extractLen, node, candidateLen, priorReason) {
+  const coverage = ((extractLen / bodyTextLen) * 100).toFixed(1);
+  const gain = (candidateLen / Math.max(extractLen, 1)).toFixed(1);
+  return `coverage guard: ${coverage}% coverage of ${bodyTextLen}c body, `
+    + `recovered ${containerLabel(node)} (${gain}x); prior pick: ${priorReason}`;
+}

--- a/lib/coverage-guard.js
+++ b/lib/coverage-guard.js
@@ -12,8 +12,7 @@
  * the body text — that is what distinguishes "one article split across siblings"
  * from "many separate teasers".
  *
- * Thresholds are calibrated against an 85-page live corpus; see
- * docs/superpowers/specs/2026-07-29-coverage-guard-design.md.
+ * Thresholds are calibrated against an 85-page live corpus.
  */
 import { metrics } from './scoring.js';
 
@@ -69,8 +68,11 @@ export function shouldAttempt(bodyTextLen, extractLen) {
 export function findDominantContainer(body) {
   if (!body) return null;
   let node = body;
+  // parentLen tracks textLength(node). The first iteration measures the body;
+  // every later iteration reuses best.len from the iteration that descended
+  // into this exact node, instead of recomputing the same textContent walk.
+  let parentLen = textLength(node);
   for (let depth = 0; depth < GUARD_LIMITS.MAX_DEPTH; depth++) {
-    const parentLen = textLength(node);
     if (parentLen === 0) break;
     let best = null;
     for (const child of node.children) {
@@ -79,6 +81,7 @@ export function findDominantContainer(body) {
     }
     if (best === null || best.len / parentLen < GUARD_LIMITS.DOMINANCE) break;
     node = best.el;
+    parentLen = best.len;
   }
   return node === body ? null : node;
 }

--- a/lib/web.js
+++ b/lib/web.js
@@ -513,8 +513,13 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
   // Readability.parse() mutates the document it is handed (measured on a
   // page-builder one-pager: 336670c of body text down to 310722c), so measuring
   // afterwards would compare against an already-stripped denominator. Skipped
-  // when the caller forced an extractor — the guard will not run either.
-  const guardBodyLen = extractor ? 0 : bodyTextLength(document);
+  // when the caller forced a STATIC extractor (readability/trafilatura) - the
+  // guard will not run either. `extractor === 'playwright'` still takes this
+  // (default pickBest) path on the static pass, so it must not disable the
+  // guard here: doing so would silently drop the guard's coverage on every
+  // page-builder one-pager fetched with extractor=playwright.
+  const staticForced = extractor === 'readability' || extractor === 'trafilatura';
+  const guardBodyLen = staticForced ? 0 : bodyTextLength(document);
 
   const reader = new Readability(document);
   const article = reader.parse();
@@ -573,10 +578,11 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
   // re-convert that container instead — effectively an auto-written
   // `select.content`, using the same conversion path a recipe would take.
   //
-  // Runs only on the default path: a forced `extractor=` skips it (explicit
-  // beats heuristic), and a recipe `select.content` that matched has already
-  // returned above. It can only grow the result, never shrink it.
-  if (!extractor && shouldAttempt(guardBodyLen, chosenMd.trim().length)) {
+  // Runs only on the default path: a forced static `extractor=` skips it
+  // (explicit beats heuristic), and a recipe `select.content` that matched has
+  // already returned above. `extractor === 'playwright'` does NOT skip it (see
+  // the guardBodyLen comment above). It can only grow the result, never shrink it.
+  if (!staticForced && shouldAttempt(guardBodyLen, chosenMd.trim().length)) {
     try {
       const extractLen = chosenMd.trim().length;
       // cleanedHtml already carries preprocess + recipe removeSelectors; re-parse
@@ -855,11 +861,21 @@ export async function extractWeb(url, options = {}) {
       userAgent,
     });
     const rendered = await convertWithReadability(url, renderedHtml, comments, statusCode, rawFetchFn, effectiveExtractor, recipe);
-    rendered.source = 'playwright';
     const renderReason = effectiveExtractor === 'playwright'
       ? 'forced via extractor=playwright'
       : `${decision.reason} → rendered via playwright`;
-    rendered.metadata.extractorReason = renderReason;
+    // The coverage guard can fire on THIS (rendered) pass too. When it does,
+    // keep its 'coverage-guard' source and reason instead of overwriting them
+    // with 'playwright' - the guard's intervention on the rendered DOM is more
+    // specific and more useful to an operator than the generic render note.
+    // Both facts (that a render happened, and that the guard then intervened)
+    // are kept, not just one.
+    if (rendered.source === 'coverage-guard') {
+      rendered.metadata.extractorReason = `${renderReason} | ${rendered.metadata.extractorReason}`;
+    } else {
+      rendered.source = 'playwright';
+      rendered.metadata.extractorReason = renderReason;
+    }
     emit('extracting', { source: 'playwright' });
     return rendered;
   } catch (err) {

--- a/lib/web.js
+++ b/lib/web.js
@@ -6,6 +6,7 @@ import { safeFetch } from './ssrf.js';
 import { pickBest, qualityScore } from './scoring.js';
 import { renderDecision } from './render-decision.js';
 import {
+  GUARD_LIMITS,
   bodyTextLength,
   shouldAttempt,
   findDominantContainer,
@@ -518,8 +519,13 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
   // (default pickBest) path on the static pass, so it must not disable the
   // guard here: doing so would silently drop the guard's coverage on every
   // page-builder one-pager fetched with extractor=playwright.
+  // Serialized HTML is always at least as long as the text it contains, so a
+  // document under the floor cannot possibly reach it — skip the textContent
+  // walk entirely on the ordinary small page rather than on every request.
   const staticForced = extractor === 'readability' || extractor === 'trafilatura';
-  const guardBodyLen = staticForced ? 0 : bodyTextLength(document);
+  const guardBodyLen = (staticForced || cleanedHtml.length < GUARD_LIMITS.MIN_BODY_TEXT)
+    ? 0
+    : bodyTextLength(document);
 
   const reader = new Readability(document);
   const article = reader.parse();

--- a/lib/web.js
+++ b/lib/web.js
@@ -5,6 +5,13 @@ import { extractMetadata } from './metadata.js';
 import { safeFetch } from './ssrf.js';
 import { pickBest, qualityScore } from './scoring.js';
 import { renderDecision } from './render-decision.js';
+import {
+  bodyTextLength,
+  shouldAttempt,
+  findDominantContainer,
+  acceptCandidate,
+  guardReason,
+} from './coverage-guard.js';
 import { renderViaSidecar } from './playwright-client.js';
 import { pickUserAgent, maybeRefreshUaPool } from './user-agent.js';
 import { preprocess } from './preprocess.js';
@@ -502,6 +509,13 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
       : `matched only ${selectedMd.trim().length}c`;
   }
 
+  // The coverage guard needs the cleaned body size BEFORE Readability runs:
+  // Readability.parse() mutates the document it is handed (measured on a
+  // page-builder one-pager: 336670c of body text down to 310722c), so measuring
+  // afterwards would compare against an already-stripped denominator. Skipped
+  // when the caller forced an extractor — the guard will not run either.
+  const guardBodyLen = extractor ? 0 : bodyTextLength(document);
+
   const reader = new Readability(document);
   const article = reader.parse();
 
@@ -550,6 +564,35 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
         : (readabilityFellBack ? 'readability-fallback' : 'readability');
       extractorReason = decision.reason;
     }
+  }
+
+  // Coverage guard: Readability commits to a single best candidate, so on pages
+  // whose body is one wrapper full of flat sibling blocks it can keep one block
+  // and silently drop the rest. When the chosen extract covers only a sliver of
+  // the cleaned body AND a single container holds nearly all of that body,
+  // re-convert that container instead — effectively an auto-written
+  // `select.content`, using the same conversion path a recipe would take.
+  //
+  // Runs only on the default path: a forced `extractor=` skips it (explicit
+  // beats heuristic), and a recipe `select.content` that matched has already
+  // returned above. It can only grow the result, never shrink it.
+  if (!extractor && shouldAttempt(guardBodyLen, chosenMd.trim().length)) {
+    try {
+      const extractLen = chosenMd.trim().length;
+      // cleanedHtml already carries preprocess + recipe removeSelectors; re-parse
+      // because Readability mutated the working document.
+      const { document: guardDoc } = parseHTML(cleanedHtml);
+      cleanDom(guardDoc);
+      const container = findDominantContainer(guardDoc.querySelector('body'));
+      if (container) {
+        const candidateMd = nhm.translate(container.innerHTML);
+        if (acceptCandidate(candidateMd, extractLen)) {
+          extractorReason = guardReason(guardBodyLen, extractLen, container, candidateMd.trim().length, extractorReason);
+          chosenMd = candidateMd;
+          source = 'coverage-guard';
+        }
+      }
+    } catch { /* the guard must never break extraction */ }
   }
 
   metadata.quality = qualityScore(chosenMd, { rawHtml: cleanedHtml });

--- a/skill/pullmd/skills/pullmd/SKILL.md
+++ b/skill/pullmd/skills/pullmd/SKILL.md
@@ -57,7 +57,7 @@ The response is `text/markdown` — ready to use as-is.
 
 **Response headers worth checking:**
 
-- `X-Source` — `reddit` · `cloudflare` · `readability` · `readability-fallback` · `trafilatura` · `playwright` · `markitdown` · `youtube` · `image-caption` · `audio-transcript` · `pdf-ocr`
+- `X-Source` — `reddit` · `cloudflare` · `readability` · `readability-fallback` · `trafilatura` · `playwright` · `recipe-content` · `coverage-guard` · `markitdown` · `youtube` · `image-caption` · `audio-transcript` · `pdf-ocr`
 - `X-Quality` — `0.0–1.0` extraction confidence (low values mean the static extraction was thin or noisy)
 - `X-Share-Id` — 8-hex permalink, openable as `__PULLMD_URL__/s/<id>` (absent for `/api/html` — local conversions are never cached or shared)
 

--- a/test/coverage-guard.test.js
+++ b/test/coverage-guard.test.js
@@ -11,7 +11,7 @@ import {
   containerLabel,
   guardReason,
 } from '../lib/coverage-guard.js';
-import { extractHtml } from '../lib/web.js';
+import { extractHtml, extractWeb } from '../lib/web.js';
 import { RecipeSchema } from '../lib/recipes.js';
 
 const bodyOf = (inner) => parseHTML(`<html><body>${inner}</body></html>`).document.querySelector('body');
@@ -293,6 +293,19 @@ describe('coverage guard guard-rails', () => {
     assert.doesNotMatch(result.metadata.extractorReason, /coverage guard/);
   });
 
+  it('still fires when the extractor is pinned to playwright', async () => {
+    // extractor=playwright still takes the DEFAULT pickBest path on the static
+    // pass (only readability/trafilatura pins skip Readability+Trafilatura
+    // entirely) - so the guard must NOT treat it like a static forced
+    // extractor. extractHtml's own `extractor` option only accepts
+    // 'readability'/'trafilatura' (see its JSDoc), so drive this through a
+    // recipe's `extractor: playwright` instead, exactly as a real site
+    // configuration would.
+    const recipe = RecipeSchema.parse({ name: 'test', host: 'example.com', extractor: 'playwright' });
+    const result = await extractHtml(onePager(), { url: PAGE_URL, recipes: [recipe] });
+    assert.equal(result.source, 'coverage-guard');
+  });
+
   it('is switched off by PULLMD_COVERAGE_GUARD=off', async () => {
     const result = await withGuardEnvAsync('off', () => extractHtml(onePager(), { url: PAGE_URL, recipes: [] }));
     assert.notEqual(result.source, 'coverage-guard');
@@ -303,5 +316,32 @@ describe('coverage guard guard-rails', () => {
     const guarded = await extractHtml(onePager(), { url: PAGE_URL, recipes: [] });
     assert.ok(guarded.markdown.length >= forced.markdown.length,
       'the guard must only ever grow the extract');
+  });
+});
+
+describe('coverage guard on the rendered (Playwright) pass', () => {
+  function fetchThinHtml() {
+    return async () => {
+      const headers = { get: (k) => (k.toLowerCase() === 'content-type' ? 'text/html; charset=utf-8' : null) };
+      return { ok: true, status: 200, headers, text: async () => '<html><body><p>thin</p></body></html>' };
+    };
+  }
+
+  it('keeps the coverage-guard source and reason when the guard fires on the rendered DOM', async () => {
+    // render: 'force' makes the second (Playwright) pass happen regardless of
+    // what the static extraction looks like; the injected renderClient hands
+    // back the one-pager fixture, so the guard fires on the SECOND
+    // convertWithReadability call (the rendered one), not the first. Before the
+    // fix, extractWeb unconditionally overwrote source/extractorReason with
+    // 'playwright', losing the guard's transparency markers.
+    const result = await extractWeb(PAGE_URL, {
+      fetch: fetchThinHtml(),
+      recipes: [],
+      render: 'force',
+      renderClient: async () => onePager(),
+    });
+    assert.equal(result.source, 'coverage-guard');
+    assert.match(result.metadata.extractorReason, /forced via render=force/);
+    assert.match(result.metadata.extractorReason, /coverage guard:/);
   });
 });

--- a/test/coverage-guard.test.js
+++ b/test/coverage-guard.test.js
@@ -1,0 +1,171 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseHTML } from 'linkedom';
+import {
+  GUARD_LIMITS,
+  isEnabled,
+  bodyTextLength,
+  shouldAttempt,
+  findDominantContainer,
+  acceptCandidate,
+  containerLabel,
+  guardReason,
+} from '../lib/coverage-guard.js';
+
+const bodyOf = (inner) => parseHTML(`<html><body>${inner}</body></html>`).document.querySelector('body');
+
+// Runs fn with PULLMD_COVERAGE_GUARD set to value, then restores the previous value.
+function withGuardEnv(value, fn) {
+  const prev = process.env.PULLMD_COVERAGE_GUARD;
+  if (value === undefined) delete process.env.PULLMD_COVERAGE_GUARD;
+  else process.env.PULLMD_COVERAGE_GUARD = value;
+  try { return fn(); } finally {
+    if (prev === undefined) delete process.env.PULLMD_COVERAGE_GUARD;
+    else process.env.PULLMD_COVERAGE_GUARD = prev;
+  }
+}
+
+describe('coverage guard limits', () => {
+  it('pins the calibrated constants', () => {
+    assert.equal(GUARD_LIMITS.MIN_BODY_TEXT, 20_000);
+    assert.equal(GUARD_LIMITS.MAX_COVERAGE, 0.10);
+    assert.equal(GUARD_LIMITS.DOMINANCE, 0.90);
+    assert.equal(GUARD_LIMITS.MIN_GAIN, 3);
+    assert.equal(GUARD_LIMITS.MIN_PARAGRAPHS, 5);
+  });
+});
+
+describe('isEnabled', () => {
+  it('defaults to on', () => {
+    assert.equal(withGuardEnv(undefined, isEnabled), true);
+  });
+
+  it('is off only for the literal off switch, case and space tolerant', () => {
+    assert.equal(withGuardEnv('off', isEnabled), false);
+    assert.equal(withGuardEnv('OFF', isEnabled), false);
+    assert.equal(withGuardEnv(' off ', isEnabled), false);
+    assert.equal(withGuardEnv('false', isEnabled), true);
+    assert.equal(withGuardEnv('on', isEnabled), true);
+  });
+});
+
+describe('bodyTextLength', () => {
+  it('collapses whitespace before measuring', () => {
+    assert.equal(bodyTextLength(parseHTML('<html><body>  a\n\n   b  </body></html>').document), 3);
+  });
+
+  it('returns 0 when there is no body', () => {
+    assert.equal(bodyTextLength({ querySelector: () => null }), 0);
+  });
+
+  it('returns 0 for a nullish document', () => {
+    assert.equal(bodyTextLength(null), 0);
+  });
+});
+
+describe('shouldAttempt', () => {
+  it('skips bodies below the size floor even at absurd coverage', () => {
+    assert.equal(shouldAttempt(19_999, 1), false);
+  });
+
+  it('fires on a large body with a sliver of an extract', () => {
+    assert.equal(shouldAttempt(100_000, 3_000), true);
+  });
+
+  it('skips when coverage is at or above the ceiling', () => {
+    assert.equal(shouldAttempt(100_000, 10_000), false);
+    assert.equal(shouldAttempt(100_000, 9_999), true);
+  });
+
+  it('skips entirely when the guard is switched off', () => {
+    assert.equal(withGuardEnv('off', () => shouldAttempt(100_000, 3_000)), false);
+  });
+});
+
+describe('findDominantContainer', () => {
+  const PROSE = 'x'.repeat(1000);
+
+  it('descends into the single container that holds the text', () => {
+    const body = bodyOf(`<div class="wrap"><div class="a">${PROSE}</div><div class="b">short</div></div>`);
+    const node = findDominantContainer(body);
+    assert.equal(node.getAttribute('class'), 'wrap');
+  });
+
+  it('descends several levels while one child keeps dominating', () => {
+    const body = bodyOf(`<div class="outer"><div class="inner"><div class="a">${PROSE}</div><div class="b">short</div></div></div>`);
+    assert.equal(findDominantContainer(body).getAttribute('class'), 'inner');
+  });
+
+  it('returns null when the text is spread across siblings of the body', () => {
+    const body = bodyOf(`<div class="a">${PROSE}</div><div class="b">${PROSE}</div><div class="c">${PROSE}</div>`);
+    assert.equal(findDominantContainer(body), null);
+  });
+
+  it('ignores children that carry no text', () => {
+    const body = bodyOf(`<div class="wrap"><span class="empty"></span><div class="a">${PROSE}</div></div>`);
+    assert.equal(findDominantContainer(body).getAttribute('class'), 'wrap');
+  });
+
+  it('returns null for an empty body', () => {
+    assert.equal(findDominantContainer(bodyOf('')), null);
+  });
+
+  it('returns null for a nullish body', () => {
+    assert.equal(findDominantContainer(null), null);
+  });
+
+  it('stops at the depth limit instead of walking forever', () => {
+    let html = `${PROSE}`;
+    for (let i = 0; i < 60; i++) html = `<div class="d${i}">${html}</div>`;
+    const node = findDominantContainer(bodyOf(html));
+    assert.ok(node, 'expected a container');
+    // The wrappers are built inside-out, so d59 is outermost. MAX_DEPTH descents
+    // from the body land on d30 — verified, not derived.
+    assert.equal(node.getAttribute('class'), 'd30');
+  });
+});
+
+describe('acceptCandidate', () => {
+  const para = (n) => Array.from({ length: n }, (_, i) => `Paragraph number ${i} is comfortably longer than forty characters.`).join('\n\n');
+
+  it('rejects a candidate that is not substantially larger', () => {
+    assert.equal(acceptCandidate(para(20), para(20).length), false);
+  });
+
+  it('rejects a large candidate without prose structure', () => {
+    const navSoup = '- link\n'.repeat(2000);
+    assert.equal(acceptCandidate(navSoup, 100), false);
+  });
+
+  it('accepts a large candidate with prose structure', () => {
+    assert.equal(acceptCandidate(para(30), 100), true);
+  });
+
+  it('treats a zero-length extract as length one instead of dividing by zero', () => {
+    assert.equal(acceptCandidate(para(30), 0), true);
+  });
+});
+
+describe('containerLabel', () => {
+  it('prefers the id', () => {
+    assert.equal(containerLabel(bodyOf('<div id="main" class="a b">x</div>').firstElementChild), 'div#main');
+  });
+
+  it('falls back to the first class', () => {
+    assert.equal(containerLabel(bodyOf('<div class="a b">x</div>').firstElementChild), 'div.a');
+  });
+
+  it('falls back to the bare tag name', () => {
+    assert.equal(containerLabel(bodyOf('<section>x</section>').firstElementChild), 'section');
+  });
+});
+
+describe('guardReason', () => {
+  it('states coverage, body size, container and gain, and keeps the prior reason', () => {
+    const node = bodyOf('<div class="elementor">x</div>').firstElementChild;
+    const reason = guardReason(336_670, 10_503, node, 339_923, 'comparable, prefer baseline');
+    assert.match(reason, /^coverage guard: 3\.1% coverage of 336670c body/);
+    assert.match(reason, /recovered div\.elementor \(32\.4x\)/);
+    assert.match(reason, /prior pick: comparable, prefer baseline$/);
+  });
+});

--- a/test/coverage-guard.test.js
+++ b/test/coverage-guard.test.js
@@ -85,15 +85,29 @@ describe('shouldAttempt', () => {
 describe('findDominantContainer', () => {
   const PROSE = 'x'.repeat(1000);
 
-  it('descends into the single container that holds the text', () => {
-    const body = bodyOf(`<div class="wrap"><div class="a">${PROSE}</div><div class="b">short</div></div>`);
-    const node = findDominantContainer(body);
-    assert.equal(node.getAttribute('class'), 'wrap');
+  it('stops where the text branches across siblings', () => {
+    const body = bodyOf(`<div class="wrap"><div class="a">${PROSE}</div><div class="b">${PROSE}</div></div>`);
+    assert.equal(findDominantContainer(body).getAttribute('class'), 'wrap');
   });
 
   it('descends several levels while one child keeps dominating', () => {
-    const body = bodyOf(`<div class="outer"><div class="inner"><div class="a">${PROSE}</div><div class="b">short</div></div></div>`);
+    const body = bodyOf(`<div class="outer"><div class="inner"><div class="a">${PROSE}</div><div class="b">${PROSE}</div></div></div>`);
     assert.equal(findDominantContainer(body).getAttribute('class'), 'inner');
+  });
+
+  it('keeps descending past small siblings instead of stopping at them', () => {
+    // A sibling that holds a sliver of the text is not a branch point. This is
+    // the property that separates "one container owns the page" from "the page
+    // has several parts", and it is what makes the guard work on real markup.
+    const body = bodyOf(`<div class="wrap"><div class="a">${PROSE}</div><div class="b">short</div></div>`);
+    assert.equal(findDominantContainer(body).getAttribute('class'), 'a');
+  });
+
+  it('finds the dominant container even when the body itself has several children', () => {
+    // Real cleaned pages keep more than one child under body. Requiring a single
+    // child here would make the guard silently never fire.
+    const body = bodyOf(`<div class="main">${PROSE}</div><div class="tiny">short</div>`);
+    assert.equal(findDominantContainer(body).getAttribute('class'), 'main');
   });
 
   it('returns null when the text is spread across siblings of the body', () => {
@@ -103,7 +117,7 @@ describe('findDominantContainer', () => {
 
   it('ignores children that carry no text', () => {
     const body = bodyOf(`<div class="wrap"><span class="empty"></span><div class="a">${PROSE}</div></div>`);
-    assert.equal(findDominantContainer(body).getAttribute('class'), 'wrap');
+    assert.equal(findDominantContainer(body).getAttribute('class'), 'a');
   });
 
   it('returns null for an empty body', () => {
@@ -119,8 +133,6 @@ describe('findDominantContainer', () => {
     for (let i = 0; i < 60; i++) html = `<div class="d${i}">${html}</div>`;
     const node = findDominantContainer(bodyOf(html));
     assert.ok(node, 'expected a container');
-    // The wrappers are built inside-out, so d59 is outermost. MAX_DEPTH descents
-    // from the body land on d30 — verified, not derived.
     assert.equal(node.getAttribute('class'), 'd30');
   });
 });

--- a/test/coverage-guard.test.js
+++ b/test/coverage-guard.test.js
@@ -11,6 +11,7 @@ import {
   containerLabel,
   guardReason,
 } from '../lib/coverage-guard.js';
+import { extractHtml } from '../lib/web.js';
 
 const bodyOf = (inner) => parseHTML(`<html><body>${inner}</body></html>`).document.querySelector('body');
 
@@ -179,5 +180,56 @@ describe('guardReason', () => {
     assert.match(reason, /^coverage guard: 3\.1% coverage of 336670c body/);
     assert.match(reason, /recovered div\.elementor \(32\.4x\)/);
     assert.match(reason, /prior pick: comparable, prefer baseline$/);
+  });
+});
+
+// A page-builder one-pager in miniature: one wrapper, a shallow preamble that
+// Readability scores highest, and many chapters whose prose sits several levels
+// deeper inside accordion items. Readability's candidate score dilutes with
+// depth, so it keeps the preamble and drops every chapter — the exact failure
+// this guard exists for. Built in code because test/fixtures/ is public.
+const SENTENCE = 'The maintenance schedule for the district heating network was revised after the winter review, and the operators agreed to publish updated figures every quarter. ';
+const prose = (n) => SENTENCE.repeat(n);
+
+function onePager({ wrapped = true, introParas = 5, chapters = 12, items = 6 } = {}) {
+  const intro = `<div class="page-block"><div class="block-inner"><h2>Preamble</h2>`
+    + `<div class="page-block"><div class="intro-wrapper">`
+    + Array.from({ length: introParas }, () => `<p>${prose(2)}</p>`).join('')
+    + `</div></div></div></div>`;
+  const chapter = (i) => `<div class="page-block"><div class="block-inner"><h2>Chapter ${i}</h2>`
+    + `<div class="page-block"><div class="accordion-wrapper"><div class="accordion">`
+    + Array.from({ length: items }, (_, j) =>
+      `<div class="accordion-item"><div class="accordion-head"><h3>Item ${i}.${j + 1}</h3></div>`
+      + `<div class="accordion-panel">${Array.from({ length: 2 }, () => `<p>${prose(1)}</p>`).join('')}</div></div>`).join('')
+    + `</div></div></div></div></div>`;
+  const blocks = intro + Array.from({ length: chapters }, (_, i) => chapter(i + 1)).join('');
+  const inner = wrapped ? `<div class="site-builder">${blocks}</div>` : blocks;
+  return `<html><head><title>Programme</title></head><body>`
+    + `<nav><a href="/a">Home</a></nav>${inner}<footer><p>Footer boilerplate.</p></footer></body></html>`;
+}
+
+const PAGE_URL = 'https://example.com/programme';
+
+describe('coverage guard in the extraction pipeline', () => {
+  it('recovers the full body of a page-builder one-pager', async () => {
+    const result = await extractHtml(onePager(), { url: PAGE_URL, recipes: [] });
+    assert.equal(result.source, 'coverage-guard');
+    assert.match(result.markdown, /Chapter 1\b/);
+    assert.match(result.markdown, /Chapter 12\b/);
+    assert.match(result.markdown, /Preamble/);
+  });
+
+  it('records why it intervened', async () => {
+    const result = await extractHtml(onePager(), { url: PAGE_URL, recipes: [] });
+    assert.match(result.metadata.extractorReason, /^coverage guard: \d+\.\d% coverage of \d+c body/);
+    assert.match(result.metadata.extractorReason, /recovered div\.site-builder \(\d+\.\dx\)/);
+    assert.match(result.metadata.extractorReason, /prior pick: /);
+  });
+
+  it('reports the recovered length, not the discarded one', async () => {
+    const before = await extractHtml(onePager(), { url: PAGE_URL, recipes: [], extractor: 'readability' });
+    const after = await extractHtml(onePager(), { url: PAGE_URL, recipes: [] });
+    assert.ok(after.metadata.contentLength > before.metadata.contentLength * 3,
+      `expected the guard to grow the extract, got ${before.metadata.contentLength} -> ${after.metadata.contentLength}`);
   });
 });

--- a/test/coverage-guard.test.js
+++ b/test/coverage-guard.test.js
@@ -45,6 +45,7 @@ describe('coverage guard limits', () => {
     assert.equal(GUARD_LIMITS.DOMINANCE, 0.90);
     assert.equal(GUARD_LIMITS.MIN_GAIN, 3);
     assert.equal(GUARD_LIMITS.MIN_PARAGRAPHS, 5);
+    assert.equal(GUARD_LIMITS.MAX_LABEL, 60);
   });
 });
 
@@ -183,6 +184,20 @@ describe('containerLabel', () => {
   it('falls back to the bare tag name', () => {
     assert.equal(containerLabel(bodyOf('<section>x</section>').firstElementChild), 'section');
   });
+
+  it('caps a page-controlled id so the persisted reason stays bounded', () => {
+    // id and class come from the fetched page. The label lands in the extraction
+    // log and in frontmatter, so an absurd attribute must not travel with it.
+    const node = bodyOf(`<div id="${'A'.repeat(5000)}">x</div>`).firstElementChild;
+    const label = containerLabel(node);
+    assert.ok(label.length <= GUARD_LIMITS.MAX_LABEL + 'div#'.length + 1, `label was ${label.length}c`);
+    assert.match(label, /^div#A+…$/);
+  });
+
+  it('caps a page-controlled class the same way', () => {
+    const node = bodyOf(`<div class="${'B'.repeat(500)}">x</div>`).firstElementChild;
+    assert.match(containerLabel(node), /^div\.B{60}…$/);
+  });
 });
 
 describe('guardReason', () => {
@@ -190,8 +205,16 @@ describe('guardReason', () => {
     const node = bodyOf('<div class="elementor">x</div>').firstElementChild;
     const reason = guardReason(336_670, 10_503, node, 339_923, 'comparable, prefer baseline');
     assert.match(reason, /^coverage guard: 3\.1% coverage of 336670c body/);
-    assert.match(reason, /recovered div\.elementor \(32\.4x\)/);
+    assert.match(reason, /recovered div\.elementor \(32\.4x, holds \d+% of body\)/);
     assert.match(reason, /prior pick: comparable, prefer baseline$/);
+  });
+
+  it('reports the container share of the body, which the trigger does not imply', () => {
+    // DOMINANCE is enforced per descent level, so the shares multiply: a
+    // container reached through several levels can hold far less than 90% of
+    // the body. The reason has to state the real figure, not the threshold.
+    const node = bodyOf(`<div class="deep">${'x'.repeat(500)}</div>`).firstElementChild;
+    assert.match(guardReason(1000, 10, node, 500, 'prior'), /holds 50% of body/);
   });
 });
 
@@ -234,7 +257,7 @@ describe('coverage guard in the extraction pipeline', () => {
   it('records why it intervened', async () => {
     const result = await extractHtml(onePager(), { url: PAGE_URL, recipes: [] });
     assert.match(result.metadata.extractorReason, /^coverage guard: \d+\.\d% coverage of \d+c body/);
-    assert.match(result.metadata.extractorReason, /recovered div\.site-builder \(\d+\.\dx\)/);
+    assert.match(result.metadata.extractorReason, /recovered div\.site-builder \(\d+\.\dx, holds \d+% of body\)/);
     assert.match(result.metadata.extractorReason, /prior pick: /);
   });
 

--- a/test/coverage-guard.test.js
+++ b/test/coverage-guard.test.js
@@ -255,11 +255,22 @@ describe('coverage guard guard-rails', () => {
     assert.doesNotMatch(result.metadata.extractorReason, /coverage guard/);
   });
 
-  it('stays silent on a small page', async () => {
+  it('leaves an ordinary small article untouched', async () => {
     const small = `<html><head><title>Note</title></head><body><div class="wrap"><article>`
       + `<p>${prose(3)}</p><p>${prose(3)}</p></article></div></body></html>`;
     const result = await extractHtml(small, { url: PAGE_URL, recipes: [] });
     assert.notEqual(result.source, 'coverage-guard');
+  });
+
+  it('stays silent below the body-size floor even when every other condition holds', async () => {
+    // Same shape as the firing fixture, only shorter. Measured on this fixture:
+    // body 17,635 chars (under the 20,000 floor), coverage 9.3% (under the
+    // ceiling), a dominant container is present, and the candidate would be
+    // ~10x larger. The size floor is the only thing holding the guard back, so
+    // lowering MIN_BODY_TEXT makes this test fail — which is the point.
+    const result = await extractHtml(onePager({ chapters: 8 }), { url: PAGE_URL, recipes: [] });
+    assert.notEqual(result.source, 'coverage-guard');
+    assert.doesNotMatch(result.metadata.extractorReason, /coverage guard/);
   });
 
   it('yields to a recipe select.content', async () => {

--- a/test/coverage-guard.test.js
+++ b/test/coverage-guard.test.js
@@ -12,6 +12,7 @@ import {
   guardReason,
 } from '../lib/coverage-guard.js';
 import { extractHtml } from '../lib/web.js';
+import { RecipeSchema } from '../lib/recipes.js';
 
 const bodyOf = (inner) => parseHTML(`<html><body>${inner}</body></html>`).document.querySelector('body');
 
@@ -21,6 +22,17 @@ function withGuardEnv(value, fn) {
   if (value === undefined) delete process.env.PULLMD_COVERAGE_GUARD;
   else process.env.PULLMD_COVERAGE_GUARD = value;
   try { return fn(); } finally {
+    if (prev === undefined) delete process.env.PULLMD_COVERAGE_GUARD;
+    else process.env.PULLMD_COVERAGE_GUARD = prev;
+  }
+}
+
+// Async variant for tests with async functions like extractHtml.
+async function withGuardEnvAsync(value, fn) {
+  const prev = process.env.PULLMD_COVERAGE_GUARD;
+  if (value === undefined) delete process.env.PULLMD_COVERAGE_GUARD;
+  else process.env.PULLMD_COVERAGE_GUARD = value;
+  try { return await fn(); } finally {
     if (prev === undefined) delete process.env.PULLMD_COVERAGE_GUARD;
     else process.env.PULLMD_COVERAGE_GUARD = prev;
   }
@@ -231,5 +243,54 @@ describe('coverage guard in the extraction pipeline', () => {
     const after = await extractHtml(onePager(), { url: PAGE_URL, recipes: [] });
     assert.ok(after.metadata.contentLength > before.metadata.contentLength * 3,
       `expected the guard to grow the extract, got ${before.metadata.contentLength} -> ${after.metadata.contentLength}`);
+  });
+});
+
+describe('coverage guard guard-rails', () => {
+  it('stays silent on a flat page with the same content but no dominant container', async () => {
+    // Identical text, one structural difference: no wrapper. The text is spread
+    // across body-level siblings, which is what a listing page looks like.
+    const result = await extractHtml(onePager({ wrapped: false }), { url: PAGE_URL, recipes: [] });
+    assert.notEqual(result.source, 'coverage-guard');
+    assert.doesNotMatch(result.metadata.extractorReason, /coverage guard/);
+  });
+
+  it('stays silent on a small page', async () => {
+    const small = `<html><head><title>Note</title></head><body><div class="wrap"><article>`
+      + `<p>${prose(3)}</p><p>${prose(3)}</p></article></div></body></html>`;
+    const result = await extractHtml(small, { url: PAGE_URL, recipes: [] });
+    assert.notEqual(result.source, 'coverage-guard');
+  });
+
+  it('yields to a recipe select.content', async () => {
+    const recipe = RecipeSchema.parse({
+      name: 'test', host: 'example.com', select: { content: ['.intro-wrapper'] },
+    });
+    const result = await extractHtml(onePager(), { url: PAGE_URL, recipes: [recipe] });
+    assert.equal(result.source, 'recipe-content');
+    assert.doesNotMatch(result.metadata.extractorReason, /coverage guard/);
+  });
+
+  it('yields to a forced extractor=readability', async () => {
+    const result = await extractHtml(onePager(), { url: PAGE_URL, recipes: [], extractor: 'readability' });
+    assert.equal(result.source, 'readability');
+    assert.equal(result.metadata.extractorReason, 'forced via extractor=readability');
+  });
+
+  it('yields to a forced extractor=trafilatura even when the sidecar is unavailable', async () => {
+    const result = await extractHtml(onePager(), { url: PAGE_URL, recipes: [], extractor: 'trafilatura' });
+    assert.doesNotMatch(result.metadata.extractorReason, /coverage guard/);
+  });
+
+  it('is switched off by PULLMD_COVERAGE_GUARD=off', async () => {
+    const result = await withGuardEnvAsync('off', () => extractHtml(onePager(), { url: PAGE_URL, recipes: [] }));
+    assert.notEqual(result.source, 'coverage-guard');
+  });
+
+  it('never shrinks the result', async () => {
+    const forced = await extractHtml(onePager(), { url: PAGE_URL, recipes: [], extractor: 'readability' });
+    const guarded = await extractHtml(onePager(), { url: PAGE_URL, recipes: [] });
+    assert.ok(guarded.markdown.length >= forced.markdown.length,
+      'the guard must only ever grow the extract');
   });
 });


### PR DESCRIPTION
Closes #46

## What

Adds `lib/coverage-guard.js` and wires it into the default extraction path. It notices when an extraction kept only a sliver of the page and recovers the container that holds the body - effectively an auto-written `select.content`, using the same conversion path a recipe takes.

## Why the failure is invisible today

Readability distributes a paragraph's score across its ancestors, divided down with depth. On a page-builder one-pager the preamble has its paragraphs directly in its container and wins the top candidate; the chapters split their prose across many accordion items three or four levels deeper, so their common ancestor only collects fractions. The chapters are not siblings of the top candidate either, so they are never appended. Result: well-formed markdown containing 3% of the page.

## Trigger

All five conditions must hold:

1. no recipe `select.content`, no forced static extractor, not the comments path
2. cleaned body text >= 20,000 characters
3. coverage (extract / body) < 10%
4. a single container holds >= 90% of the body text
5. the candidate is >= 3x larger and has >= 5 paragraphs

Condition 4 is the discriminator. It separates "one article split across siblings" from "many separate teasers", and it is what keeps listing pages out.

## Calibration

85 live pages: the Hacker News front page, the p2-1 eval corpus, 12 server-rendered forum threads and comment-heavy blog posts, wikis, long single-document pages (GPL-3.0, RFC 9110, MDN, Python docs), shops, listing homepages, and four page-builder landing pages.

| filter | pages left |
|---|---|
| all | 85 |
| body >= 20k | 17 |
| + coverage < 10% | 2 |
| + dominant container | 1 |
| + gain and prose | 1 |

Forum threads: 0 of 12 fire, their coverage runs 17.7-258%. The nearest non-target miss is a listing homepage at 1.9% coverage, blocked by condition 4.

Threshold sensitivity: the first false positive appears at coverage < 20% (a forum thread at 19.8%) or at body >= 10k with coverage < 15% (a landing page at 11.7%). The shipped thresholds sit with roughly a factor of 2 in hand.

The sweep was re-run against the shipped code before opening this PR, with the gate model and the real pipeline cross-checked against each other on every page. They agree everywhere.

## Safety

The guard can only grow a result, never shrink it - condition 5 requires a 3x gain, and anything that does not hold leaves today's output untouched. The whole block is wrapped in try/catch and degrades to current behaviour. Opt out with `PULLMD_COVERAGE_GUARD=off`. Every intervention carries `source: coverage-guard` and records the figures it acted on in `metadata.extractorReason`, so an operator can judge afterwards whether it was warranted.

Side effect worth noting: on the motivating page the recovered extract raises the quality score from 0.45 to 0.8, which puts it above the `renderDecision` threshold. The page needed no JavaScript, so this also removes a pointless Playwright round-trip.

## Deliberately not changed

`pickBest`. Relaxing its heading gate would let Trafilatura's heading-less output win on these pages, push coverage to ~95% and silence the guard, trading a structured result for a flat one.

## Tests

1035 passing, 0 failing (baseline before the branch: 995). The new tests cover the descent algorithm, the trigger thresholds, and the cases where the guard must stay silent: a structurally flat twin of the firing fixture with identical content, a page below the size floor that meets every other condition, a recipe `select.content`, forced static extractors, and the opt-out. Test fixtures are generated in-test from neutral prose.

Python sidecar tests pass, and the query-extract goldens are byte-identical - no re-capture needed.

## Known limitation

`emit('extracting', ...)` still reports `playwright` when the guard fires on a rendered pass. That is a transient progress event only; the persisted `source` and `extractorReason` are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1rQhLmVXHnJvurKvfGgfg