### PR TITLE
feat(#49): scope history deletes to the caller, add PULLMD_ALLOW_SIGNUP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,13 @@
 # that admin. See MIGRATION.md.
 # PULLMD_AUTH_MODE=disabled
 
+# Self-registration in multi-user mode. Default: on. Set to false/0/no/off to
+# close /signup (the route stops existing, the login page drops its
+# "create an account" link). Use this to run a public demo instance without
+# letting strangers register. Create accounts yourself with
+# `node scripts/admin.js create-user someone@example.com`.
+# PULLMD_ALLOW_SIGNUP=true
+
 # Bootstrap credentials for the first admin user. Required on first startup
 # when PULLMD_AUTH_MODE != disabled. After the admin exists, changing these
 # does not change the password — use `node scripts/admin.js reset-password`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -111,6 +111,7 @@ If you don't set `PULLMD_AUTH_MODE`, nothing changes. Skip the rest.
 2. Decide which auth mode you want:
    - `single-admin` — one user, no self-signup, simplest for homelab.
    - `multi-user` — self-signup at `/signup`, per-user history.
+     Since 3.8.0, self-signup can be closed with `PULLMD_ALLOW_SIGNUP=false` while staying in `multi-user` mode.
 3. Pick admin credentials. The first startup with auth enabled requires `PULLMD_ADMIN_EMAIL` + `PULLMD_ADMIN_PASSWORD`.
 
 ## Upgrading

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ All variables go in `.env` (copy from `.env.example`):
 | `PULLMD_USER_AGENT`    | no       | Pin a single outbound User-Agent for every web fetch. Disables rotation. Useful for CI or when one specific UA is known to work. |
 | `PULLMD_UA_FEED_URL`   | no       | URL of a JSON feed of current real-world UAs. Default: [WinFuture23/real-world-user-agents](https://github.com/WinFuture23/real-world-user-agents). Set to an empty string to disable live refresh and rely on the built-in seed pool. |
 | `PULLMD_AUTH_MODE`     | no       | `disabled` (default) / `single-admin` / `multi-user`. See "Authentication" below.                   |
+| `PULLMD_ALLOW_SIGNUP`  | no       | Self-registration in `multi-user` mode. Default: on. `false` / `0` / `no` / `off` closes `/signup` (404) and removes the "create an account" link from the login page. Accounts can still be created with `node scripts/admin.js create-user <email>`. |
 | `PULLMD_ADMIN_EMAIL`   | required when AUTH_MODE != disabled, on first startup | Bootstrap email for the first admin user.                            |
 | `PULLMD_ADMIN_PASSWORD` | required when AUTH_MODE != disabled, on first startup | Bootstrap password (min 8 chars).                                    |
 | `PULLMD_AUTH_TOKEN`    | no       | Legacy bearer token compat (single-admin mode only, deprecated).                                    |
@@ -256,7 +257,7 @@ PullMD ships with three auth modes. Pick one with `PULLMD_AUTH_MODE`:
 | -------------- | --------------------------------------------------------------------------- |
 | `disabled`     | Default. No auth, everything open. Existing v1.x behavior.                  |
 | `single-admin` | One user, credentials from env vars. No self-signup. For homelab.           |
-| `multi-user`   | Self-signup at `/signup`, login at `/login`, per-user data isolation.       |
+| `multi-user`   | Self-signup at `/signup` (unless `PULLMD_ALLOW_SIGNUP` is off), login at `/login`, per-user data isolation. |
 
 In `single-admin` and `multi-user` modes, `PULLMD_ADMIN_EMAIL` + `PULLMD_ADMIN_PASSWORD` bootstrap the first admin user on first startup. After that, changing these env vars does **not** change the password — use the admin CLI:
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,13 @@ In `single-admin` and `multi-user` modes, `PULLMD_ADMIN_EMAIL` + `PULLMD_ADMIN_P
 docker compose exec pullmd node scripts/admin.js reset-password you@example.com
 ```
 
+Create an account without opening self-registration (useful when
+`PULLMD_ALLOW_SIGNUP` is off):
+
+```bash
+docker compose exec pullmd node scripts/admin.js create-user someone@example.com
+```
+
 ### Auth boundary
 
 | Endpoint                                                         | Auth required (when mode != disabled) |

--- a/README.md
+++ b/README.md
@@ -275,8 +275,14 @@ docker compose exec pullmd node scripts/admin.js reset-password you@example.com
 | `POST /api/html`, `POST /api/file`                               |                 yes                  |
 | `/mcp`                                                           |                 yes                  |
 | `/api/history`, `/api/archive`                                   |                 yes                  |
-| `/api/cache/:id`, `DELETE /api/cache`                            |                 yes                  |
+| `DELETE /api/cache/:id`, `DELETE /api/cache`                     |                 yes                  |
 | `/api/stats`, `/api/storage`, `/api/config` (aggregate)          |                  no                  |
+
+Cache deletes are scoped to the caller. An admin (and every caller in
+`disabled` mode) removes the shared, URL-deduped cache row, which affects
+every user's history. A regular user only unlinks the entry from their own
+history - the shared row and its `/s/:id` share link keep working. The
+response says which happened via `"scope": "user" | "global"`.
 
 ### Authentication paths
 

--- a/REVIEW-FINDINGS.md
+++ b/REVIEW-FINDINGS.md
@@ -68,6 +68,10 @@ Bug, not theoretical — anyone who reads the OSS source can `curl` it.
 keeps current behaviour (no auth, anyone can delete). Implemented in this
 review.
 
+Superseded in 3.8.0: a non-admin delete is now scoped to the caller's own
+history instead of rejected outright. See the README's Auth boundary
+section for the current behaviour.
+
 ---
 
 ## NICE TO HAVE — follow-ups, not release blockers

--- a/lib/auth-pages.js
+++ b/lib/auth-pages.js
@@ -155,11 +155,18 @@ function errorBlock(error) {
 
 export const _ERR_KEYS = Object.keys(ERR); // exposed for tests
 
-export function loginPage({ error = '', email = '', next = '', mode = '' } = {}) {
+export function loginPage({ error = '', email = '', next = '', mode = '', signupOpen = false } = {}) {
   const hint = mode === 'single-admin'
     ? `<div class="muted env-hint" style="font-size: 0.75rem; margin-top: 0.5rem;">
          <span lang="de">Verwende PULLMD_ADMIN_EMAIL und PULLMD_ADMIN_PASSWORD aus deiner Environment-Konfiguration.</span><span lang="en">Use the PULLMD_ADMIN_EMAIL and PULLMD_ADMIN_PASSWORD from your environment.</span>
        </div>`
+    : '';
+  // Only render the link when /signup is actually mounted. It is gated on the
+  // effective value, not on the mode - see PULLMD_ALLOW_SIGNUP.
+  const signupLink = signupOpen
+    ? `<div class="muted">
+    <a href="/signup"><span lang="de">Konto erstellen</span><span lang="en">Create an account</span></a>
+  </div>`
     : '';
   return `<!DOCTYPE html><html lang="de"><head><meta charset="UTF-8"><title>Login — PullMD</title>${PAGE_STYLE}</head>
 <body>
@@ -179,9 +186,7 @@ export function loginPage({ error = '', email = '', next = '', mode = '' } = {})
     <input type="password" name="password" required>
   </label>
   <button type="submit"><span lang="de">Anmelden</span><span lang="en">Sign in</span></button>
-  <div class="muted">
-    <a href="/signup"><span lang="de">Konto erstellen</span><span lang="en">Create an account</span></a>
-  </div>
+  ${signupLink}
   ${hint}
 </form>
 ${INIT_LANG_SCRIPT}

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -117,7 +117,7 @@ export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLo
 
   // Raw switch vs. effective reachability: /signup only exists in multi-user,
   // so a `true` flag in single-admin would misreport the surface.
-  const signupAllowed = allowSignup ?? readAllowSignupEnv(env);
+  const signupAllowed = allowSignup == null ? readAllowSignupEnv(env) : !!allowSignup;
   const signupOpen = mode === 'multi-user' && signupAllowed;
 
   const stmts = {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -70,6 +70,18 @@ function logMisconfigBanner(logger = console.warn) {
 }
 
 /**
+ * Default-on switch for self-registration. Only an explicit falsy value closes
+ * signup, so existing multi-user instances keep self-registration across an
+ * upgrade. Mirrors readDisablePublicHistoryEnv in server.js, inverted.
+ */
+function readAllowSignupEnv(env = {}) {
+  const v = env.PULLMD_ALLOW_SIGNUP;
+  if (v == null) return true;
+  const s = String(v).toLowerCase().trim();
+  return !(s === 'false' || s === '0' || s === 'no' || s === 'off');
+}
+
+/**
  * Format the bootstrap-credentials-missing error as a multi-line block.
  * Used by server.js's direct-run path to produce a readable, actionable
  * message instead of a stack trace when PULLMD_AUTH_MODE is set without
@@ -90,7 +102,7 @@ export function formatBootstrapError(mode) {
   ].join('\n');
 }
 
-export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLogger, publicUrl } = {}) {
+export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLogger, publicUrl, allowSignup } = {}) {
   if (!['disabled', 'single-admin', 'multi-user'].includes(mode)) {
     throw new Error(`Invalid PULLMD_AUTH_MODE: ${mode}`);
   }
@@ -102,6 +114,11 @@ export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLo
   if (isMisconfigured) {
     logMisconfigBanner(warnLogger || console.warn);
   }
+
+  // Raw switch vs. effective reachability: /signup only exists in multi-user,
+  // so a `true` flag in single-admin would misreport the surface.
+  const signupAllowed = allowSignup ?? readAllowSignupEnv(env);
+  const signupOpen = mode === 'multi-user' && signupAllowed;
 
   const stmts = {
     insertSession: db.prepare(`
@@ -476,7 +493,7 @@ export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLo
 
     app.get('/login', (req, res) => {
       res.set('Content-Type', 'text/html; charset=utf-8');
-      res.send(loginPage({ next: req.query.next || '', mode }));
+      res.send(loginPage({ next: req.query.next || '', mode, signupOpen }));
     });
 
     app.post('/login', formParser, async (req, res) => {
@@ -484,7 +501,7 @@ export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLo
       const user = await authenticate(email, password);
       if (!user) {
         res.status(401).set('Content-Type', 'text/html; charset=utf-8');
-        return res.send(loginPage({ error: 'wrong_credentials', email, next, mode }));
+        return res.send(loginPage({ error: 'wrong_credentials', email, next, mode, signupOpen }));
       }
       const { token } = createSession(user.id);
       setSessionCookie(res, token, isSecureRequest(req));
@@ -498,7 +515,7 @@ export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLo
       res.redirect(302, '/');
     });
 
-    if (mode === 'multi-user') {
+    if (signupOpen) {
       app.get('/signup', (req, res) => {
         res.set('Content-Type', 'text/html; charset=utf-8');
         res.send(signupPage({}));
@@ -581,6 +598,8 @@ export function createAuth({ db, mode = 'disabled', env = {}, argon2Opts, warnLo
   return {
     mode,
     isMisconfigured,
+    allowSignup: signupAllowed,
+    signupOpen,
     runMigration,
     createSession, lookupSession, deleteSession,
     setSessionFlash, consumeSessionFlash,

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -210,6 +210,18 @@ export function createCache(dbPath = '/data/cache.db') {
     count: db.prepare(`SELECT COUNT(*) as total FROM conversions`),
     deleteOne: db.prepare(`DELETE FROM conversions WHERE id = ?`),
     deleteAll: db.prepare(`DELETE FROM conversions`),
+    deleteFetchesForCache: db.prepare(`DELETE FROM user_fetches WHERE cache_id = ?`),
+    deleteAllFetches: db.prepare(`DELETE FROM user_fetches`),
+    forgetFetch: db.prepare(`DELETE FROM user_fetches WHERE user_id = ? AND cache_id = ?`),
+    forgetAllFetches: db.prepare(`DELETE FROM user_fetches WHERE user_id = ?`),
+    // user_fetches.cache_id has no FK to conversions (and enabling
+    // PRAGMA foreign_keys globally would change behaviour well outside this
+    // module), so fetch rows are cleaned explicitly. Without this, countForUser
+    // counts rows historyPageForUser cannot join and the archive paginates
+    // toward entries that never arrive.
+    pruneOrphanFetches: db.prepare(`
+      DELETE FROM user_fetches WHERE cache_id NOT IN (SELECT id FROM conversions)
+    `),
     pruneOld: db.prepare(`
       DELETE FROM conversions WHERE created_at < datetime('now', '-90 days')
     `),
@@ -268,6 +280,10 @@ export function createCache(dbPath = '/data/cache.db') {
     `),
   };
 
+  // One-time sweep so a database written by an older build (where pruneOld
+  // dropped conversions without their fetch rows) starts out consistent.
+  stmts.pruneOrphanFetches.run();
+
   return {
     db,
 
@@ -275,7 +291,10 @@ export function createCache(dbPath = '/data/cache.db') {
       const shareId = generateShareId();
       const metaJson = metadata != null ? JSON.stringify(metadata) : null;
       stmts.upsert.run(url, title, markdown, source, shareId, client || 'browser', user_id, metaJson);
-      stmts.pruneOld.run();
+      const pruned = stmts.pruneOld.run();
+      // Only pay for the orphan scan when the 90-day prune actually removed
+      // something, which is rare - put() runs on every conversion.
+      if (pruned.changes > 0) stmts.pruneOrphanFetches.run();
       const row = db.prepare('SELECT id, share_id FROM conversions WHERE url = ?').get(url);
       if (user_id != null && row?.id) {
         stmts.upsertFetch.run(user_id, row.id);
@@ -319,11 +338,31 @@ export function createCache(dbPath = '/data/cache.db') {
     },
 
     delete(id) {
-      return stmts.deleteOne.run(id);
+      const run = db.transaction((cacheId) => {
+        stmts.deleteFetchesForCache.run(cacheId);
+        return stmts.deleteOne.run(cacheId);
+      });
+      return run(id);
     },
 
     deleteAll() {
-      return stmts.deleteAll.run();
+      const run = db.transaction(() => {
+        stmts.deleteAllFetches.run();
+        return stmts.deleteAll.run();
+      });
+      return run();
+    },
+
+    forgetForUser(userId, cacheId) {
+      return stmts.forgetFetch.run(userId, cacheId);
+    },
+
+    forgetAllForUser(userId) {
+      return stmts.forgetAllFetches.run(userId);
+    },
+
+    pruneOrphanFetches() {
+      return stmts.pruneOrphanFetches.run();
     },
 
     logExtraction({ url, source, quality, markdownLen, extractorReason, durationMs, client, cached }) {

--- a/public/help.html
+++ b/public/help.html
@@ -964,8 +964,8 @@ share_id: a3f9c2b7
             <td lang="en">One user from the server settings, no self-signup. For a homelab.</td>
           </tr>
           <tr><td><code>multi-user</code></td>
-            <td lang="de">Registrierung unter <code>/signup</code>, Login unter <code>/login</code>, getrennte Daten pro Benutzer.</td>
-            <td lang="en">Sign up at <code>/signup</code>, log in at <code>/login</code>, per-user data isolation.</td>
+            <td lang="de">Registrierung unter <code>/signup</code>, Login unter <code>/login</code>, getrennte Daten pro Benutzer. Die Registrierung lässt sich mit <code>PULLMD_ALLOW_SIGNUP=false</code> schließen.</td>
+            <td lang="en">Sign up at <code>/signup</code>, log in at <code>/login</code>, per-user data isolation. Self-signup can be closed with <code>PULLMD_ALLOW_SIGNUP=false</code>.</td>
           </tr>
         </tbody>
       </table>

--- a/public/index.html
+++ b/public/index.html
@@ -1382,6 +1382,7 @@
       }
       headerActions.appendChild(slot);
       document.documentElement.dataset.loggedIn = me ? '1' : '0';
+      document.documentElement.dataset.isAdmin = me && me.is_admin ? '1' : '0';
     })();
 
     // ---- i18n: DE/EN, default from navigator.language, persisted override ----
@@ -1409,7 +1410,8 @@
           'archive.more':      'Mehr laden',
           'archive.deleteAll': 'Alles löschen',
           'archive.confirmDeleteAll': 'Alle Einträge löschen?',
-          'archive.delete':    'Löschen',
+          'archive.deleteMine':   'Aus meiner Historie entfernen',
+          'archive.deleteGlobal': 'Global löschen',
           'archive.entries':   '{n} Einträge',
           'stat.entries':      'Einträge',
           'stat.entries.expiring': '{n} laufen bald ab',
@@ -1432,6 +1434,7 @@
           'err.unknown':       'Unbekannter Fehler ({code})',
           'err.empty':         'Leere Antwort vom Server.',
           'err.network':       'Netzwerkfehler: Server nicht erreichbar.',
+          'err.deleteFailed':  'Löschen fehlgeschlagen.',
           'drop.hint':         'HTML-Datei hier ablegen',
           'drop.affordance':   'Alternativ: HTML-Datei hierher ziehen oder auswählen',
           'drop.affordanceOpen': 'Alternativ: HTML-Datei auswählen',
@@ -1467,7 +1470,8 @@
           'archive.more':      'Load more',
           'archive.deleteAll': 'Delete all',
           'archive.confirmDeleteAll': 'Delete all entries?',
-          'archive.delete':    'Delete',
+          'archive.deleteMine':   'Remove from my history',
+          'archive.deleteGlobal': 'Delete globally',
           'archive.entries':   '{n} entries',
           'stat.entries':      'Entries',
           'stat.entries.expiring': '{n} expiring soon',
@@ -1490,6 +1494,7 @@
           'err.unknown':       'Unknown error ({code})',
           'err.empty':         'Empty response from server.',
           'err.network':       'Network error: server unreachable.',
+          'err.deleteFailed':  'Delete failed.',
           'drop.hint':         'Drop HTML file here',
           'drop.affordance':   'Alternatively: drag an HTML file here or browse',
           'drop.affordanceOpen': 'Alternatively: choose an HTML file',
@@ -1743,6 +1748,12 @@
       function hideLoading() {
         loadingEl.classList.remove('visible');
         goBtn.disabled = false;
+      }
+      // The /api/me fetch lives in another IIFE and resolves asynchronously.
+      // Falling back to the user-scope wording is correct: an unresolved flag
+      // means we do not know the caller is an admin.
+      function isAdminUser() {
+        return document.documentElement.dataset.isAdmin === '1';
       }
       function showError(msg) {
         hideLoading();
@@ -2402,7 +2413,7 @@
               delBtn.type = 'button';
               delBtn.className = 'h-delete-btn';
               delBtn.textContent = '×';
-              delBtn.title = t('archive.delete');
+              delBtn.title = isAdminUser() ? t('archive.deleteGlobal') : t('archive.deleteMine');
               delBtn.addEventListener('click', (function(itm, row, btn) {
                 return function(e) {
                   e.preventDefault();
@@ -2418,12 +2429,14 @@
                       btn.disabled = false;
                       row.style.borderColor = 'var(--bad)';
                       btn.title = 'Delete failed (HTTP ' + res.status + ')';
+                      showError(t('err.deleteFailed'));
                       console.warn('History delete failed:', res.status, itm.id, itm.url);
                     })
                     .catch(function(err) {
                       btn.disabled = false;
                       row.style.borderColor = 'var(--bad)';
                       btn.title = 'Delete failed: ' + err.message;
+                      showError(t('err.deleteFailed'));
                       console.warn('History delete error:', err, itm.id, itm.url);
                     });
                 };
@@ -2584,7 +2597,7 @@
         delBtn.type = 'button';
         delBtn.className = 'archive-delete-btn';
         delBtn.textContent = '×';
-        delBtn.title = t('archive.delete');
+        delBtn.title = isAdminUser() ? t('archive.deleteGlobal') : t('archive.deleteMine');
         delBtn.addEventListener('click', function(e) {
           e.preventDefault();
           e.stopPropagation();
@@ -2601,12 +2614,14 @@
               delBtn.disabled = false;
               row.style.borderColor = 'var(--bad)';
               delBtn.title = 'Delete failed (HTTP ' + res.status + ')';
+              showError(t('err.deleteFailed'));
               console.warn('Archive delete failed:', res.status, item.id, item.url);
             })
             .catch(function(err) {
               delBtn.disabled = false;
               row.style.borderColor = 'var(--bad)';
               delBtn.title = 'Delete failed: ' + err.message;
+              showError(t('err.deleteFailed'));
               console.warn('Archive delete error:', err, item.id, item.url);
             });
         });
@@ -2641,7 +2656,13 @@
             archiveTotal = 0;
             archiveCount.textContent = t('archive.entries', { n: 0 });
             archiveMoreBtn.style.display = 'none';
+            return;
           }
+          showError(t('err.deleteFailed'));
+          console.warn('Archive delete-all failed:', res.status);
+        }).catch(function(err) {
+          showError(t('err.deleteFailed'));
+          console.warn('Archive delete-all error:', err);
         });
       });
 

--- a/public/index.html
+++ b/public/index.html
@@ -1409,7 +1409,8 @@
           'archive.back':      '← Zurück',
           'archive.more':      'Mehr laden',
           'archive.deleteAll': 'Alles löschen',
-          'archive.confirmDeleteAll': 'Alle Einträge löschen?',
+          'archive.confirmDeleteAllMine':   'Alle Einträge aus deiner Historie entfernen?',
+          'archive.confirmDeleteAllGlobal': 'Alle Einträge global löschen? Das betrifft alle Benutzer und macht bestehende Share-Links ungültig.',
           'archive.deleteMine':   'Aus meiner Historie entfernen',
           'archive.deleteGlobal': 'Global löschen',
           'archive.entries':   '{n} Einträge',
@@ -1469,7 +1470,8 @@
           'archive.back':      '← Back',
           'archive.more':      'Load more',
           'archive.deleteAll': 'Delete all',
-          'archive.confirmDeleteAll': 'Delete all entries?',
+          'archive.confirmDeleteAllMine':   'Remove all entries from your history?',
+          'archive.confirmDeleteAllGlobal': 'Delete all entries globally? This affects every user and invalidates existing share links.',
           'archive.deleteMine':   'Remove from my history',
           'archive.deleteGlobal': 'Delete globally',
           'archive.entries':   '{n} entries',
@@ -1749,11 +1751,15 @@
         loadingEl.classList.remove('visible');
         goBtn.disabled = false;
       }
-      // The /api/me fetch lives in another IIFE and resolves asynchronously.
-      // Falling back to the user-scope wording is correct: an unresolved flag
-      // means we do not know the caller is an admin.
-      function isAdminUser() {
-        return document.documentElement.dataset.isAdmin === '1';
+      // Mirrors isGlobalScope on the server: no auth configured or auth
+      // disabled means every caller deletes globally, otherwise only an admin
+      // does. dataset.authMode is set before the bootstrap's early return for
+      // disabled mode, and defaults to 'disabled' when /api/config is
+      // unreachable - the conservative side, since a global delete is the
+      // destructive one.
+      function isGlobalDelete() {
+        var root = document.documentElement;
+        return root.dataset.authMode === 'disabled' || root.dataset.isAdmin === '1';
       }
       function showError(msg) {
         hideLoading();
@@ -2422,7 +2428,7 @@
               delBtn.type = 'button';
               delBtn.className = 'h-delete-btn';
               delBtn.textContent = '×';
-              delBtn.title = isAdminUser() ? t('archive.deleteGlobal') : t('archive.deleteMine');
+              delBtn.title = isGlobalDelete() ? t('archive.deleteGlobal') : t('archive.deleteMine');
               delBtn.addEventListener('click', (function(itm, row, btn) {
                 return function(e) {
                   e.preventDefault();
@@ -2607,7 +2613,7 @@
         delBtn.type = 'button';
         delBtn.className = 'archive-delete-btn';
         delBtn.textContent = '×';
-        delBtn.title = isAdminUser() ? t('archive.deleteGlobal') : t('archive.deleteMine');
+        delBtn.title = isGlobalDelete() ? t('archive.deleteGlobal') : t('archive.deleteMine');
         delBtn.addEventListener('click', function(e) {
           e.preventDefault();
           e.stopPropagation();
@@ -2659,7 +2665,7 @@
       archiveBackBtn.addEventListener('click', function(e) { e.preventDefault(); hideArchive(); });
       archiveMoreBtn.addEventListener('click', loadArchivePage);
       archiveDeleteAllBtn.addEventListener('click', function() {
-        if (!confirm(t('archive.confirmDeleteAll'))) return;
+        if (!confirm(isGlobalDelete() ? t('archive.confirmDeleteAllGlobal') : t('archive.confirmDeleteAllMine'))) return;
         fetch('/api/cache', { method: 'DELETE' }).then(function(res) {
           if (res.ok) {
             while (archiveList.firstChild) archiveList.removeChild(archiveList.firstChild);

--- a/public/index.html
+++ b/public/index.html
@@ -1382,7 +1382,11 @@
       }
       headerActions.appendChild(slot);
       document.documentElement.dataset.loggedIn = me ? '1' : '0';
-      document.documentElement.dataset.isAdmin = me && me.is_admin ? '1' : '0';
+      // Tri-state on purpose. '1' admin, '0' a known non-admin, 'unknown' when
+      // /api/me did not answer. This line runs only after that fetch settles,
+      // so an absent attribute still means "not asked yet", which is a
+      // different situation and keeps its own default in isGlobalDelete().
+      document.documentElement.dataset.isAdmin = me ? (me.is_admin ? '1' : '0') : 'unknown';
     })();
 
     // ---- i18n: DE/EN, default from navigator.language, persisted override ----
@@ -1755,11 +1759,17 @@
       // disabled means every caller deletes globally, otherwise only an admin
       // does. dataset.authMode is set before the bootstrap's early return for
       // disabled mode, and defaults to 'disabled' when /api/config is
-      // unreachable - the conservative side, since a global delete is the
-      // destructive one.
+      // unreachable.
+      // 'unknown' means /api/me answered nothing, so the role is undecidable:
+      // overwarn. Claiming "global" for a delete that turns out to be scoped
+      // costs nothing, while the reverse puts a harmless label on a
+      // destructive action. An absent attribute is the different case of
+      // "bootstrap still running" and keeps the scoped default.
       function isGlobalDelete() {
         var root = document.documentElement;
-        return root.dataset.authMode === 'disabled' || root.dataset.isAdmin === '1';
+        return root.dataset.authMode === 'disabled'
+          || root.dataset.isAdmin === '1'
+          || root.dataset.isAdmin === 'unknown';
       }
       function showError(msg) {
         hideLoading();

--- a/public/index.html
+++ b/public/index.html
@@ -1759,7 +1759,16 @@
         hideLoading();
         errorEl.textContent = msg;
         errorEl.classList.add('visible');
-        resultContainer.classList.remove('visible');
+        // showArchive() hides the shared views with an inline display:none, and an
+        // inline style outranks the .error.visible class rule. Clear it, or a
+        // delete that fails inside the archive view would show nothing at all.
+        errorEl.style.display = '';
+        // Only collapse a shown conversion result on the main view. From the
+        // archive this would silently drop the user's result for when they
+        // navigate back, since hideArchive() restores display but not classes.
+        if (!archiveView || !archiveView.classList.contains('visible')) {
+          resultContainer.classList.remove('visible');
+        }
       }
 
       var sourceBadge = document.getElementById('source-badge');
@@ -2564,6 +2573,7 @@
         if (mainView) mainView.style.display = '';
         if (heroView) heroView.style.display = '';
         resultViews.forEach(function(el) { if (el) el.style.display = ''; });
+        errorEl.classList.remove('visible');
         loadHistory();
       }
       function formatDate(dateStr) {

--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -95,7 +95,6 @@ async function main() {
     mode: process.env.PULLMD_AUTH_MODE || 'multi-user',
     env: process.env,
   });
-  await auth.runMigration();
 
   if (cmd === 'list-users') {
     const users = listUsers({ db: cache.db });

--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -28,6 +28,19 @@ export function makeAdmin({ db }, email) {
   return r.changes > 0;
 }
 
+export async function createUserCmd({ db, auth }, email, password) {
+  const clean = String(email || '').trim().toLowerCase();
+  if (db.prepare("SELECT 1 FROM users WHERE email = ?").get(clean)) {
+    return { ok: false, reason: 'exists' };
+  }
+  try {
+    const user = await auth.createUser({ email, password, isAdmin: false });
+    return { ok: true, user };
+  } catch (err) {
+    return { ok: false, reason: 'invalid', message: err?.message || 'could not create user' };
+  }
+}
+
 async function readPassword(prompt = 'New password: ') {
   process.stdout.write(prompt);
   return new Promise((resolve) => {
@@ -66,7 +79,7 @@ async function readPassword(prompt = 'New password: ') {
 async function main() {
   const [, , cmd, ...args] = process.argv;
   if (!cmd) {
-    console.error('Usage: node scripts/admin.js <list-users|reset-password|make-admin> [email]');
+    console.error('Usage: node scripts/admin.js <list-users|create-user|reset-password|make-admin> [email]');
     process.exit(1);
   }
   const dbPath = process.env.CACHE_DB || './data/cache.db';
@@ -76,6 +89,7 @@ async function main() {
     mode: process.env.PULLMD_AUTH_MODE || 'multi-user',
     env: process.env,
   });
+  await auth.runMigration();
 
   if (cmd === 'list-users') {
     const users = listUsers({ db: cache.db });
@@ -103,6 +117,22 @@ async function main() {
     const ok = makeAdmin({ db: cache.db }, email);
     if (!ok) { console.error(`No user with email ${email}`); process.exit(2); }
     console.log(`${email} is now an admin.`);
+    return;
+  }
+
+  if (cmd === 'create-user') {
+    const email = args[0];
+    if (!email) { console.error('Usage: create-user <email>'); process.exit(2); }
+    const pw = await readPassword();
+    if (!pw || pw.length < 8) { console.error('Password must be at least 8 characters.'); process.exit(2); }
+    const r = await createUserCmd({ db: cache.db, auth }, email, pw);
+    if (!r.ok) {
+      console.error(r.reason === 'exists'
+        ? `A user with email ${email} already exists.`
+        : r.message);
+      process.exit(2);
+    }
+    console.log(`Created ${r.user.email} (no admin rights). Use make-admin to promote.`);
     return;
   }
 

--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -43,13 +43,19 @@ export async function createUserCmd({ db, auth }, email, password) {
 
 async function readPassword(prompt = 'New password: ') {
   process.stdout.write(prompt);
-  return new Promise((resolve) => {
-    if (!process.stdin.isTTY) {
-      // Fallback: read line normally if not interactive (pipe/test).
-      const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-      rl.question('', (answer) => { rl.close(); resolve(answer); });
-      return;
+  // Non-interactive stdin (a pipe, or a test): node:readline/promises
+  // question() returns a promise and ignores a callback, so it has to be
+  // awaited. Passing a callback here silently never fires and the process
+  // exits without having read anything.
+  if (!process.stdin.isTTY) {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    try {
+      return await rl.question('');
+    } finally {
+      rl.close();
     }
+  }
+  return new Promise((resolve) => {
     process.stdin.setRawMode(true);
     let buf = '';
     const onData = (chunk) => {

--- a/server.js
+++ b/server.js
@@ -1023,18 +1023,14 @@ export function createApp(overrides = {}) {
     }
     const id = parseInt(req.params.id, 10);
     if (!id) return res.status(400).json({ error: 'Invalid ID' });
-    if (isGlobalScope(req)) {
-      const result = cache.delete(id);
-      if (!result.changes) {
-        return res.status(404).json({ error: 'Entry not found', id });
-      }
-      return res.json({ ok: true, id, scope: 'global' });
-    }
-    const result = cache.forgetForUser(req.user.id, id);
+    const global = isGlobalScope(req);
+    const result = global
+      ? cache.delete(id)
+      : cache.forgetForUser(req.user.id, id);
     if (!result.changes) {
       return res.status(404).json({ error: 'Entry not found', id });
     }
-    res.json({ ok: true, id, scope: 'user' });
+    res.json({ ok: true, id, scope: global ? 'global' : 'user' });
   });
 
   app.delete('/api/cache', gate, (req, res) => {

--- a/server.js
+++ b/server.js
@@ -1024,14 +1024,14 @@ export function createApp(overrides = {}) {
     }
     const id = parseInt(req.params.id, 10);
     if (!id) return res.status(400).json({ error: 'Invalid ID' });
-    const global = isGlobalScope(req);
-    const result = global
+    const isGlobal = isGlobalScope(req);
+    const result = isGlobal
       ? cache.delete(id)
       : cache.forgetForUser(req.user.id, id);
     if (!result.changes) {
       return res.status(404).json({ error: 'Entry not found', id });
     }
-    res.json({ ok: true, id, scope: global ? 'global' : 'user' });
+    res.json({ ok: true, id, scope: isGlobal ? 'global' : 'user' });
   });
 
   app.delete('/api/cache', gate, (req, res) => {

--- a/server.js
+++ b/server.js
@@ -980,6 +980,7 @@ export function createApp(overrides = {}) {
       disablePublicHistory,
       authMode: auth ? auth.mode : 'disabled',
       authMisconfigured: !!auth?.isMisconfigured,
+      signupOpen: !!auth?.signupOpen,
       markitdown: !!process.env.MARKITDOWN_URL,
       vision: !!(process.env.PULLMD_VISION_API_KEY || process.env.PULLMD_LLM_API_KEY),
       stt: !!(process.env.PULLMD_STT_API_KEY || process.env.PULLMD_LLM_API_KEY),

--- a/server.js
+++ b/server.js
@@ -115,14 +115,11 @@ export function createApp(overrides = {}) {
 
   const gate = auth ? auth.requireAuth() : (req, res, next) => next();
 
-  // Cache deletes touch the global URL-deduped store — they affect every
-  // user's history, not just the caller's. Restrict to admin in any
-  // non-disabled mode. In disabled mode, anyone can call (v1 behaviour).
-  const adminOnly = (req, res, next) => {
-    if (!auth || auth.mode === 'disabled') return next();
-    if (req.user?.is_admin) return next();
-    return res.status(403).json({ error: 'Admin required' });
-  };
+  // Delete scope depends on the caller. The cache is URL-deduped and shared,
+  // so dropping a `conversions` row affects every user's history - that stays
+  // admin-only. A regular user's delete only unlinks the entry from their own
+  // history (`user_fetches`); the shared row and its share link survive.
+  const isGlobalScope = (req) => !auth || auth.mode === 'disabled' || !!req.user?.is_admin;
 
   // Templated help page + skill zip (PUBLIC_URL substitution).
   // Must come BEFORE express.static so they win over the raw files in /public.
@@ -1020,25 +1017,36 @@ export function createApp(overrides = {}) {
     res.json(cache.historyPage(limit, offset));
   });
 
-  app.delete('/api/cache/:id', gate, adminOnly, (req, res) => {
+  app.delete('/api/cache/:id', gate, (req, res) => {
     if (!cache) {
       return res.status(404).json({ error: 'Cache not available' });
     }
     const id = parseInt(req.params.id, 10);
     if (!id) return res.status(400).json({ error: 'Invalid ID' });
-    const result = cache.delete(id);
+    if (isGlobalScope(req)) {
+      const result = cache.delete(id);
+      if (!result.changes) {
+        return res.status(404).json({ error: 'Entry not found', id });
+      }
+      return res.json({ ok: true, id, scope: 'global' });
+    }
+    const result = cache.forgetForUser(req.user.id, id);
     if (!result.changes) {
       return res.status(404).json({ error: 'Entry not found', id });
     }
-    res.json({ ok: true, id });
+    res.json({ ok: true, id, scope: 'user' });
   });
 
-  app.delete('/api/cache', gate, adminOnly, (req, res) => {
+  app.delete('/api/cache', gate, (req, res) => {
     if (!cache) {
       return res.status(404).json({ error: 'Cache not available' });
     }
-    cache.deleteAll();
-    res.json({ ok: true });
+    if (isGlobalScope(req)) {
+      const result = cache.deleteAll();
+      return res.json({ ok: true, scope: 'global', removed: result.changes });
+    }
+    const result = cache.forgetAllForUser(req.user.id);
+    res.json({ ok: true, scope: 'user', removed: result.changes });
   });
 
   // Friendly JSON for body-parser limit violations. Mounted last; non-413

--- a/test/auth-admin-cli.test.js
+++ b/test/auth-admin-cli.test.js
@@ -2,7 +2,7 @@ import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { createCache } from '../lib/cache.js';
 import { createAuth } from '../lib/auth.js';
-import { resetPassword, listUsers, makeAdmin } from '../scripts/admin.js';
+import { resetPassword, listUsers, makeAdmin, createUserCmd } from '../scripts/admin.js';
 
 const fastOpts = { timeCost: 1, memoryCost: 1024, parallelism: 1 };
 
@@ -49,5 +49,67 @@ describe('admin CLI commands', () => {
     assert.equal(ok, true);
     const u = cache.db.prepare("SELECT is_admin FROM users WHERE email = ?").get('other@x.y');
     assert.equal(u.is_admin, 1);
+  });
+});
+
+describe('admin CLI create-user', () => {
+  let cache, auth;
+  beforeEach(async () => {
+    cache = createCache(':memory:');
+    auth = createAuth({
+      db: cache.db, mode: 'multi-user',
+      env: { PULLMD_ADMIN_EMAIL: 'a@b.c', PULLMD_ADMIN_PASSWORD: 'pw1234567' },
+      argon2Opts: fastOpts,
+    });
+    await auth.runMigration();
+    await auth.createUser({ email: 'other@x.y', password: 'pw1234567' });
+  });
+
+  it('creates a non-admin user that can authenticate', async () => {
+    const r = await createUserCmd({ db: cache.db, auth }, 'fresh@x.y', 'pw1234567');
+
+    assert.equal(r.ok, true);
+    assert.equal(r.user.email, 'fresh@x.y');
+    assert.equal(r.user.is_admin, false);
+    const u = await auth.authenticate('fresh@x.y', 'pw1234567');
+    assert.ok(u, 'the new user must be able to log in');
+    assert.equal(u.is_admin, false);
+  });
+
+  it('normalises the email like signup does', async () => {
+    const r = await createUserCmd({ db: cache.db, auth }, '  MiXeD@X.Y  ', 'pw1234567');
+
+    assert.equal(r.ok, true);
+    assert.equal(r.user.email, 'mixed@x.y');
+  });
+
+  it('refuses a duplicate email without throwing', async () => {
+    const r = await createUserCmd({ db: cache.db, auth }, 'other@x.y', 'pw1234567');
+
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'exists');
+    assert.equal(cache.db.prepare("SELECT COUNT(*) c FROM users WHERE email = ?").get('other@x.y').c, 1);
+  });
+
+  it('refuses a duplicate that differs only in case', async () => {
+    const r = await createUserCmd({ db: cache.db, auth }, 'OTHER@X.Y', 'pw1234567');
+
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'exists');
+  });
+
+  it('refuses a short password', async () => {
+    const r = await createUserCmd({ db: cache.db, auth }, 'short@x.y', 'pw1');
+
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'invalid');
+    assert.match(r.message, /at least 8/);
+  });
+
+  it('refuses an invalid email', async () => {
+    const r = await createUserCmd({ db: cache.db, auth }, 'not-an-email', 'pw1234567');
+
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'invalid');
   });
 });

--- a/test/auth-admin-cli.test.js
+++ b/test/auth-admin-cli.test.js
@@ -5,11 +5,14 @@ import os from 'node:os';
 import fs from 'node:fs';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
 import { createCache } from '../lib/cache.js';
 import { createAuth } from '../lib/auth.js';
 import { resetPassword, listUsers, makeAdmin, createUserCmd } from '../scripts/admin.js';
 
 const fastOpts = { timeCost: 1, memoryCost: 1024, parallelism: 1 };
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
 
 describe('admin CLI commands', () => {
   let cache, auth;
@@ -166,6 +169,48 @@ describe('admin CLI create-user integration (non-TTY stdin)', () => {
       assert.match(stdout, /Created someone@example\.com.*no admin rights/);
     } finally {
       // Clean up
+      if (fs.existsSync(tmpDbPath)) {
+        fs.unlinkSync(tmpDbPath);
+      }
+    }
+  });
+});
+
+describe('admin CLI list-users without any bootstrap env (regression for runMigration removal)', () => {
+  it('exits 0, reports no users, and leaves the users table empty', async () => {
+    const tmpDbPath = path.join(os.tmpdir(), `pullmd-cli-test-${Date.now()}-${Math.random().toString(16).slice(2)}.db`);
+
+    try {
+      // Deliberately no PULLMD_AUTH_MODE, PULLMD_ADMIN_EMAIL or PULLMD_ADMIN_PASSWORD.
+      // Built explicitly (not spread from process.env) so the test does not
+      // depend on the caller's shell environment.
+      const proc = execFile(process.execPath, ['scripts/admin.js', 'list-users'], {
+        cwd: ROOT,
+        env: {
+          CACHE_DB: tmpDbPath,
+        },
+        timeout: 30000,
+      });
+
+      const { stdout, stderr, code } = await new Promise((resolve, reject) => {
+        let stdoutData = '';
+        let stderrData = '';
+        proc.stdout.on('data', (d) => { stdoutData += d; });
+        proc.stderr.on('data', (d) => { stderrData += d; });
+        proc.on('error', reject);
+        proc.on('exit', (exitCode) => {
+          resolve({ stdout: stdoutData, stderr: stderrData, code: exitCode });
+        });
+      });
+
+      assert.equal(code, 0, `expected exit 0, got ${code}. stderr: ${stderr}`);
+      assert.match(stdout, /\(no users yet\)/);
+
+      // The important assertion: no bootstrap admin was created as a side effect.
+      const dbCache = createCache(tmpDbPath);
+      const count = dbCache.db.prepare("SELECT COUNT(*) c FROM users").get().c;
+      assert.equal(count, 0, 'the users table must remain empty');
+    } finally {
       if (fs.existsSync(tmpDbPath)) {
         fs.unlinkSync(tmpDbPath);
       }

--- a/test/auth-admin-cli.test.js
+++ b/test/auth-admin-cli.test.js
@@ -1,5 +1,10 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { createCache } from '../lib/cache.js';
 import { createAuth } from '../lib/auth.js';
 import { resetPassword, listUsers, makeAdmin, createUserCmd } from '../scripts/admin.js';
@@ -111,5 +116,59 @@ describe('admin CLI create-user', () => {
 
     assert.equal(r.ok, false);
     assert.equal(r.reason, 'invalid');
+  });
+});
+
+describe('admin CLI create-user integration (non-TTY stdin)', () => {
+  it('reads password from piped stdin and creates the user', async () => {
+    const tmpDbPath = path.join(os.tmpdir(), `pullmd-cli-test-${Date.now()}-${Math.random().toString(16).slice(2)}.db`);
+
+    try {
+      // Spawn the CLI with piped stdin
+      const proc = execFile('node', ['scripts/admin.js', 'create-user', 'someone@example.com'], {
+        cwd: new URL('..', import.meta.url).pathname,
+        env: {
+          ...process.env,
+          CACHE_DB: tmpDbPath,
+          PULLMD_AUTH_MODE: 'multi-user',
+          PULLMD_ADMIN_EMAIL: 'admin@x.y',
+          PULLMD_ADMIN_PASSWORD: 'pw1234567',
+        },
+        timeout: 30000, // 30 seconds, accounting for argon2 cost
+      });
+
+      // Write password to stdin
+      proc.stdin.write('pw1234567\n');
+      proc.stdin.end();
+
+      // Wait for process to complete
+      const { stdout, stderr } = await new Promise((resolve, reject) => {
+        let stdoutData = '';
+        let stderrData = '';
+        proc.stdout.on('data', (d) => { stdoutData += d; });
+        proc.stderr.on('data', (d) => { stderrData += d; });
+        proc.on('error', reject);
+        proc.on('exit', (code) => {
+          if (code === 0) {
+            resolve({ stdout: stdoutData, stderr: stderrData });
+          } else {
+            reject(new Error(`CLI exited with code ${code}: ${stderrData}`));
+          }
+        });
+      });
+
+      // Verify the user was created in the database
+      const dbCache = createCache(tmpDbPath);
+      const user = dbCache.db.prepare("SELECT id, email, is_admin FROM users WHERE email = ?").get('someone@example.com');
+      assert.ok(user, 'user should exist in the database');
+      assert.equal(user.email, 'someone@example.com');
+      assert.equal(user.is_admin, 0);
+      assert.match(stdout, /Created someone@example\.com.*no admin rights/);
+    } finally {
+      // Clean up
+      if (fs.existsSync(tmpDbPath)) {
+        fs.unlinkSync(tmpDbPath);
+      }
+    }
   });
 });

--- a/test/auth-admin-cli.test.js
+++ b/test/auth-admin-cli.test.js
@@ -129,7 +129,7 @@ describe('admin CLI create-user integration (non-TTY stdin)', () => {
     try {
       // Spawn the CLI with piped stdin
       const proc = execFile('node', ['scripts/admin.js', 'create-user', 'someone@example.com'], {
-        cwd: new URL('..', import.meta.url).pathname,
+        cwd: ROOT,
         env: {
           ...process.env,
           CACHE_DB: tmpDbPath,
@@ -167,6 +167,7 @@ describe('admin CLI create-user integration (non-TTY stdin)', () => {
       assert.equal(user.email, 'someone@example.com');
       assert.equal(user.is_admin, 0);
       assert.match(stdout, /Created someone@example\.com.*no admin rights/);
+      assert.equal(stderr, '');
     } finally {
       // Clean up
       if (fs.existsSync(tmpDbPath)) {

--- a/test/auth-pages-i18n.test.js
+++ b/test/auth-pages-i18n.test.js
@@ -15,7 +15,7 @@ function bothLangs(html, dePattern, enPattern) {
 
 describe('auth-pages: parallel lang spans', () => {
   it('login page contains both DE and EN spans for every label', () => {
-    const html = loginPage({});
+    const html = loginPage({ signupOpen: true });
     // Page uses the parallel-lang i18n pattern from help.html.
     assert.match(html, /body\[data-lang="de"\] \[lang="en"\] \{ display: none/);
     assert.match(html, /body\[data-lang="en"\] \[lang="de"\] \{ display: none/);

--- a/test/auth-signup-switch.test.js
+++ b/test/auth-signup-switch.test.js
@@ -1,0 +1,160 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createApp } from '../server.js';
+import { createCache } from '../lib/cache.js';
+import { createAuth } from '../lib/auth.js';
+import { loginPage } from '../lib/auth-pages.js';
+
+const fastOpts = { timeCost: 1, memoryCost: 1024, parallelism: 1 };
+const bootstrapEnv = { PULLMD_ADMIN_EMAIL: 'a@b.c', PULLMD_ADMIN_PASSWORD: 'pw1234567' };
+
+function makeAuth(mode, env = {}, allowSignup) {
+  const cache = createCache(':memory:');
+  const auth = createAuth({
+    db: cache.db, mode,
+    env: { ...bootstrapEnv, ...env },
+    allowSignup,
+    argon2Opts: fastOpts,
+  });
+  return { cache, auth };
+}
+
+async function withApp(mode, env, fn) {
+  const { cache, auth } = makeAuth(mode, env);
+  await auth.runMigration();
+  const app = createApp({ cache, auth });
+  const server = app.listen(0);
+  try {
+    return await fn(`http://127.0.0.1:${server.address().port}`, { cache, auth });
+  } finally {
+    server.close();
+  }
+}
+
+describe('PULLMD_ALLOW_SIGNUP parsing', () => {
+  it('defaults to on when unset', () => {
+    assert.equal(makeAuth('multi-user').auth.allowSignup, true);
+  });
+
+  for (const v of ['false', 'FALSE', ' false ', '0', 'no', 'off', 'Off']) {
+    it(`treats ${JSON.stringify(v)} as off`, () => {
+      assert.equal(makeAuth('multi-user', { PULLMD_ALLOW_SIGNUP: v }).auth.allowSignup, false);
+    });
+  }
+
+  for (const v of ['true', '1', 'yes', 'on', '']) {
+    it(`treats ${JSON.stringify(v)} as on`, () => {
+      assert.equal(makeAuth('multi-user', { PULLMD_ALLOW_SIGNUP: v }).auth.allowSignup, true);
+    });
+  }
+
+  it('honours an explicit override over the env', () => {
+    assert.equal(makeAuth('multi-user', { PULLMD_ALLOW_SIGNUP: 'false' }, true).auth.allowSignup, true);
+  });
+
+  it('signupOpen is false outside multi-user even when signup is allowed', () => {
+    assert.equal(makeAuth('single-admin').auth.signupOpen, false);
+    assert.equal(makeAuth('multi-user').auth.signupOpen, true);
+    assert.equal(makeAuth('multi-user', { PULLMD_ALLOW_SIGNUP: 'off' }).auth.signupOpen, false);
+  });
+});
+
+describe('signup routes follow the switch', () => {
+  it('multi-user with signup allowed serves /signup', async () => {
+    await withApp('multi-user', {}, async (base) => {
+      assert.equal((await fetch(base + '/signup')).status, 200);
+    });
+  });
+
+  it('multi-user with signup off returns 404 for GET and POST', async () => {
+    await withApp('multi-user', { PULLMD_ALLOW_SIGNUP: 'false' }, async (base) => {
+      assert.equal((await fetch(base + '/signup')).status, 404);
+      const post = await fetch(base + '/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'email=x@y.z&password=pw1234567&password_confirm=pw1234567',
+      });
+      assert.equal(post.status, 404);
+    });
+  });
+
+  it('signup off does not create a user', async () => {
+    await withApp('multi-user', { PULLMD_ALLOW_SIGNUP: 'false' }, async (base, { cache }) => {
+      await fetch(base + '/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'email=sneak@y.z&password=pw1234567&password_confirm=pw1234567',
+      });
+      assert.equal(cache.db.prepare("SELECT COUNT(*) c FROM users WHERE email = ?").get('sneak@y.z').c, 0);
+    });
+  });
+
+  it('single-admin never serves /signup', async () => {
+    await withApp('single-admin', {}, async (base) => {
+      assert.equal((await fetch(base + '/signup')).status, 404);
+    });
+  });
+});
+
+describe('login page signup link', () => {
+  it('renders the link when signup is reachable', () => {
+    assert.match(loginPage({ mode: 'multi-user', signupOpen: true }), /href="\/signup"/);
+  });
+
+  it('omits the link when signup is closed', () => {
+    assert.doesNotMatch(loginPage({ mode: 'multi-user', signupOpen: false }), /href="\/signup"/);
+  });
+
+  it('omits the link in single-admin mode (regression: dead link)', () => {
+    assert.doesNotMatch(loginPage({ mode: 'single-admin' }), /href="\/signup"/);
+  });
+
+  it('the served login page matches the switch', async () => {
+    await withApp('multi-user', {}, async (base) => {
+      assert.match(await (await fetch(base + '/login')).text(), /href="\/signup"/);
+    });
+    await withApp('multi-user', { PULLMD_ALLOW_SIGNUP: 'false' }, async (base) => {
+      assert.doesNotMatch(await (await fetch(base + '/login')).text(), /href="\/signup"/);
+    });
+    await withApp('single-admin', {}, async (base) => {
+      assert.doesNotMatch(await (await fetch(base + '/login')).text(), /href="\/signup"/);
+    });
+  });
+
+  it('keeps the link out of the failed-login re-render when signup is closed', async () => {
+    await withApp('multi-user', { PULLMD_ALLOW_SIGNUP: 'false' }, async (base) => {
+      const r = await fetch(base + '/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'email=a@b.c&password=wrongpassword',
+      });
+      assert.equal(r.status, 401);
+      assert.doesNotMatch(await r.text(), /href="\/signup"/);
+    });
+  });
+});
+
+describe('/api/config exposes the effective value', () => {
+  it('reports signupOpen true only for multi-user with signup allowed', async () => {
+    await withApp('multi-user', {}, async (base) => {
+      assert.equal((await (await fetch(base + '/api/config')).json()).signupOpen, true);
+    });
+    await withApp('multi-user', { PULLMD_ALLOW_SIGNUP: 'false' }, async (base) => {
+      assert.equal((await (await fetch(base + '/api/config')).json()).signupOpen, false);
+    });
+    await withApp('single-admin', {}, async (base) => {
+      assert.equal((await (await fetch(base + '/api/config')).json()).signupOpen, false);
+    });
+  });
+
+  it('reports false when auth is not configured at all', async () => {
+    const app = createApp({ cache: createCache(':memory:') });
+    const server = app.listen(0);
+    try {
+      const base = `http://127.0.0.1:${server.address().port}`;
+      assert.equal((await (await fetch(base + '/api/config')).json()).signupOpen, false);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/cache-users.test.js
+++ b/test/cache-users.test.js
@@ -1,5 +1,8 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { createCache } from '../lib/cache.js';
 
 describe('cache schema for auth', () => {
@@ -117,5 +120,127 @@ describe('cache: user-scoped history', () => {
     cache.put({ url: 'https://a.com', title: 'A2', markdown: '# A2', source: 'r', user_id: userA });
     const c = cache.db.prepare("SELECT COUNT(*) c FROM user_fetches WHERE user_id = ?").get(userA).c;
     assert.equal(c, 1);
+  });
+});
+
+describe('cache: per-user history unlink', () => {
+  let cache, uid;
+  beforeEach(() => {
+    cache = createCache(':memory:');
+    const r = cache.db.prepare("INSERT INTO users (email, password_hash) VALUES (?, ?)").run('u@x.y', 'h');
+    uid = r.lastInsertRowid;
+  });
+
+  it('forgetForUser removes only the caller fetch row, not the conversion', () => {
+    const shareId = cache.put({ url: 'https://a.test/1', title: 't', markdown: '# t', source: 's', user_id: uid });
+    const id = cache.getIdByUrl('https://a.test/1');
+
+    const r = cache.forgetForUser(uid, id);
+
+    assert.equal(r.changes, 1);
+    assert.deepEqual(cache.historyForUser(uid), []);
+    assert.ok(cache.getByShareId(shareId), 'share link must survive a user-scope unlink');
+    assert.equal(cache.db.prepare('SELECT COUNT(*) c FROM conversions WHERE id = ?').get(id).c, 1);
+  });
+
+  it('forgetForUser reports 0 changes when the user has no fetch row', () => {
+    cache.put({ url: 'https://a.test/2', title: 't', markdown: '# t', source: 's' });
+    const id = cache.getIdByUrl('https://a.test/2');
+
+    assert.equal(cache.forgetForUser(uid, id).changes, 0);
+  });
+
+  it('forgetForUser leaves another user history untouched', () => {
+    const other = cache.db.prepare("INSERT INTO users (email, password_hash) VALUES (?, ?)").run('o@x.y', 'h').lastInsertRowid;
+    cache.put({ url: 'https://a.test/3', title: 't', markdown: '# t', source: 's', user_id: uid });
+    const id = cache.getIdByUrl('https://a.test/3');
+    cache.db.prepare('INSERT INTO user_fetches (user_id, cache_id) VALUES (?, ?)').run(other, id);
+
+    cache.forgetForUser(uid, id);
+
+    assert.equal(cache.historyForUser(other).length, 1);
+  });
+
+  it('forgetAllForUser clears only the caller rows', () => {
+    const other = cache.db.prepare("INSERT INTO users (email, password_hash) VALUES (?, ?)").run('o2@x.y', 'h').lastInsertRowid;
+    cache.put({ url: 'https://a.test/4', title: 't', markdown: '# t', source: 's', user_id: uid });
+    cache.put({ url: 'https://a.test/5', title: 't', markdown: '# t', source: 's', user_id: uid });
+    cache.put({ url: 'https://a.test/6', title: 't', markdown: '# t', source: 's', user_id: other });
+
+    const r = cache.forgetAllForUser(uid);
+
+    assert.equal(r.changes, 2);
+    assert.deepEqual(cache.historyForUser(uid), []);
+    assert.equal(cache.historyForUser(other).length, 1);
+    assert.equal(cache.db.prepare('SELECT COUNT(*) c FROM conversions').get().c, 3);
+  });
+});
+
+describe('cache: no orphaned user_fetches', () => {
+  let cache, uid;
+  beforeEach(() => {
+    cache = createCache(':memory:');
+    uid = cache.db.prepare("INSERT INTO users (email, password_hash) VALUES (?, ?)").run('u@x.y', 'h').lastInsertRowid;
+  });
+
+  const orphanCount = (cache) => cache.db.prepare(`
+    SELECT COUNT(*) c FROM user_fetches f
+    LEFT JOIN conversions c ON c.id = f.cache_id
+    WHERE c.id IS NULL
+  `).get().c;
+
+  it('delete removes the fetch rows along with the conversion', () => {
+    cache.put({ url: 'https://a.test/7', title: 't', markdown: '# t', source: 's', user_id: uid });
+    const id = cache.getIdByUrl('https://a.test/7');
+
+    const r = cache.delete(id);
+
+    assert.equal(r.changes, 1, 'return value must stay the conversions delete count');
+    assert.equal(orphanCount(cache), 0);
+  });
+
+  it('countForUser stays consistent with historyPageForUser after a global delete', () => {
+    cache.put({ url: 'https://a.test/8', title: 't', markdown: '# t', source: 's', user_id: uid });
+    cache.put({ url: 'https://a.test/9', title: 't', markdown: '# t', source: 's', user_id: uid });
+    cache.delete(cache.getIdByUrl('https://a.test/8'));
+
+    const page = cache.historyPageForUser(uid, 50, 0);
+
+    assert.equal(page.total, page.items.length, 'total must not count rows the join cannot return');
+    assert.equal(page.total, 1);
+  });
+
+  it('deleteAll leaves no fetch rows behind', () => {
+    cache.put({ url: 'https://a.test/10', title: 't', markdown: '# t', source: 's', user_id: uid });
+
+    cache.deleteAll();
+
+    assert.equal(cache.db.prepare('SELECT COUNT(*) c FROM user_fetches').get().c, 0);
+  });
+
+  it('pruneOrphanFetches sweeps pre-existing orphans', () => {
+    cache.db.prepare('INSERT INTO user_fetches (user_id, cache_id) VALUES (?, ?)').run(uid, 999999);
+
+    const r = cache.pruneOrphanFetches();
+
+    assert.equal(r.changes, 1);
+    assert.equal(orphanCount(cache), 0);
+  });
+
+  it('createCache sweeps orphans left by an earlier process', () => {
+    // Temp-file pattern copied from test/recipes-frontmatter.test.js:126.
+    const file = path.join(os.tmpdir(), `pullmd-orphan-${Date.now()}-${Math.random().toString(16).slice(2)}.db`);
+    const first = createCache(file);
+    first.db.prepare("INSERT INTO users (email, password_hash) VALUES (?, ?)").run('u@x.y', 'h');
+    first.db.prepare('INSERT INTO user_fetches (user_id, cache_id) VALUES (?, ?)').run(1, 424242);
+    first.db.close();
+
+    try {
+      const second = createCache(file);
+      assert.equal(second.db.prepare('SELECT COUNT(*) c FROM user_fetches').get().c, 0);
+      second.db.close();
+    } finally {
+      fs.rmSync(file, { force: true });
+    }
   });
 });

--- a/test/cache-users.test.js
+++ b/test/cache-users.test.js
@@ -218,6 +218,20 @@ describe('cache: no orphaned user_fetches', () => {
     assert.equal(cache.db.prepare('SELECT COUNT(*) c FROM user_fetches').get().c, 0);
   });
 
+  it('pruneOld triggers the orphan sweep when it ages out a user-owned entry', () => {
+    cache.put({ url: 'https://a.test/11', title: 't', markdown: '# t', source: 's', user_id: uid });
+    cache.db.prepare("UPDATE conversions SET created_at = datetime('now','-91 days') WHERE url = ?").run('https://a.test/11');
+
+    // Insert a second, fresh entry - this put() is what triggers pruneOld.
+    cache.put({ url: 'https://a.test/12', title: 't', markdown: '# t', source: 's', user_id: uid });
+
+    const aged = cache.db.prepare("SELECT COUNT(*) c FROM conversions WHERE url = ?").get('https://a.test/11').c;
+    assert.equal(aged, 0, 'the aged conversion must be pruned');
+    assert.equal(orphanCount(cache), 0);
+    const page = cache.historyPageForUser(uid, 50, 0);
+    assert.equal(page.total, page.items.length, 'total must not count rows the join cannot return');
+  });
+
   it('pruneOrphanFetches sweeps pre-existing orphans', () => {
     cache.db.prepare('INSERT INTO user_fetches (user_id, cache_id) VALUES (?, ?)').run(uid, 999999);
 

--- a/test/integration-auth.test.js
+++ b/test/integration-auth.test.js
@@ -190,7 +190,7 @@ describe('integration: auth gating in createApp', () => {
   });
 });
 
-describe('integration: admin-only cache deletion', () => {
+describe('integration: cache deletion scope', () => {
   it('multi-user: non-admin gets 404 trying to delete entry not in their history', async () => {
     await withApp('multi-user', async (base, { auth, cache }) => {
       const u = await auth.createUser({ email: 'reg@x.y', password: 'pw1234567' });

--- a/test/integration-auth.test.js
+++ b/test/integration-auth.test.js
@@ -191,7 +191,7 @@ describe('integration: auth gating in createApp', () => {
 });
 
 describe('integration: admin-only cache deletion', () => {
-  it('multi-user: non-admin cannot DELETE /api/cache/:id', async () => {
+  it('multi-user: non-admin gets 404 trying to delete entry not in their history', async () => {
     await withApp('multi-user', async (base, { auth, cache }) => {
       const u = await auth.createUser({ email: 'reg@x.y', password: 'pw1234567' });
       const { fullKey } = auth.createApiKey(u.id, 'k');
@@ -205,21 +205,33 @@ describe('integration: admin-only cache deletion', () => {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${fullKey}` },
       });
-      assert.equal(r.status, 403);
+      assert.equal(r.status, 404);
       // Cache row must still exist.
       assert.ok(cache.db.prepare("SELECT 1 FROM conversions WHERE id = ?").get(id));
     });
   });
 
-  it('multi-user: non-admin cannot DELETE /api/cache (wipe all)', async () => {
-    await withApp('multi-user', async (base, { auth }) => {
+  it('multi-user: non-admin can DELETE /api/cache (clears only their own)', async () => {
+    await withApp('multi-user', async (base, { auth, cache }) => {
       const u = await auth.createUser({ email: 'reg2@x.y', password: 'pw1234567' });
       const { fullKey } = auth.createApiKey(u.id, 'k');
+      const adminId = cache.db.prepare("SELECT id FROM users WHERE is_admin = 1").get().id;
+      cache.put({
+        url: 'https://user-entry.com', title: 'U', markdown: '# U',
+        source: 'readability', client: 'api', user_id: u.id,
+      });
+      cache.put({
+        url: 'https://admin-entry.com', title: 'A', markdown: '# A',
+        source: 'readability', client: 'api', user_id: adminId,
+      });
       const r = await fetch(base + '/api/cache', {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${fullKey}` },
       });
-      assert.equal(r.status, 403);
+      assert.equal(r.status, 200);
+      assert.deepEqual(await r.json(), { ok: true, scope: 'user', removed: 1 });
+      assert.equal(cache.historyForUser(u.id).length, 0);
+      assert.equal(cache.historyForUser(adminId).length, 1);
     });
   });
 

--- a/test/integration-delete-scope.test.js
+++ b/test/integration-delete-scope.test.js
@@ -1,0 +1,152 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createApp } from '../server.js';
+import { createCache } from '../lib/cache.js';
+import { createAuth } from '../lib/auth.js';
+
+const fastOpts = { timeCost: 1, memoryCost: 1024, parallelism: 1 };
+
+async function withApp(mode, fn) {
+  const cache = createCache(':memory:');
+  const auth = createAuth({
+    db: cache.db, mode,
+    env: { PULLMD_ADMIN_EMAIL: 'a@b.c', PULLMD_ADMIN_PASSWORD: 'pw1234567' },
+    argon2Opts: fastOpts,
+  });
+  await auth.runMigration();
+
+  const ctx = { cache, auth };
+  if (mode !== 'disabled') {
+    ctx.admin = cache.db.prepare('SELECT id FROM users WHERE is_admin = 1').get();
+    ctx.demo = await auth.createUser({ email: 'demo@x.y', password: 'pw1234567', isAdmin: false });
+    ctx.adminCookie = { Cookie: `pullmd_session=${auth.createSession(ctx.admin.id).token}` };
+    ctx.demoCookie = { Cookie: `pullmd_session=${auth.createSession(ctx.demo.id).token}` };
+  }
+
+  const app = createApp({
+    cache, auth,
+    extractWeb: async () => ({
+      markdown: '# x', title: 'x', source: 'readability', metadata: { quality: 0.9 },
+    }),
+  });
+  const server = app.listen(0);
+  try {
+    return await fn(`http://127.0.0.1:${server.address().port}`, ctx);
+  } finally {
+    server.close();
+  }
+}
+
+// Seeds one conversion owned by `userId` and returns its cache id + share id.
+function seed(cache, url, userId) {
+  const shareId = cache.put({ url, title: 't', markdown: '# t', source: 's', user_id: userId });
+  return { id: cache.getIdByUrl(url), shareId };
+}
+
+describe('DELETE /api/cache/:id scope', () => {
+  it('non-admin unlinks from own history, conversion and share link survive', async () => {
+    await withApp('multi-user', async (base, ctx) => {
+      const { id, shareId } = seed(ctx.cache, 'https://a.test/1', ctx.demo.id);
+
+      const r = await fetch(`${base}/api/cache/${id}`, { method: 'DELETE', headers: ctx.demoCookie });
+
+      assert.equal(r.status, 200);
+      assert.deepEqual(await r.json(), { ok: true, id, scope: 'user' });
+      assert.deepEqual(ctx.cache.historyForUser(ctx.demo.id), []);
+      assert.ok(ctx.cache.getByShareId(shareId), 'share link must keep working');
+    });
+  });
+
+  it('non-admin delete leaves another user history untouched', async () => {
+    await withApp('multi-user', async (base, ctx) => {
+      const { id } = seed(ctx.cache, 'https://a.test/2', ctx.demo.id);
+      ctx.cache.db.prepare('INSERT INTO user_fetches (user_id, cache_id) VALUES (?, ?)')
+        .run(ctx.admin.id, id);
+
+      await fetch(`${base}/api/cache/${id}`, { method: 'DELETE', headers: ctx.demoCookie });
+
+      assert.equal(ctx.cache.historyForUser(ctx.admin.id).length, 1);
+    });
+  });
+
+  it('non-admin gets 404 for an entry that is not in their history', async () => {
+    await withApp('multi-user', async (base, ctx) => {
+      const { id } = seed(ctx.cache, 'https://a.test/3', ctx.admin.id);
+
+      const r = await fetch(`${base}/api/cache/${id}`, { method: 'DELETE', headers: ctx.demoCookie });
+
+      assert.equal(r.status, 404);
+      assert.equal(ctx.cache.db.prepare('SELECT COUNT(*) c FROM conversions WHERE id = ?').get(id).c, 1);
+    });
+  });
+
+  it('admin delete is global and leaves no orphan fetch rows', async () => {
+    await withApp('multi-user', async (base, ctx) => {
+      const { id, shareId } = seed(ctx.cache, 'https://a.test/4', ctx.demo.id);
+
+      const r = await fetch(`${base}/api/cache/${id}`, { method: 'DELETE', headers: ctx.adminCookie });
+
+      assert.equal(r.status, 200);
+      assert.deepEqual(await r.json(), { ok: true, id, scope: 'global' });
+      assert.equal(ctx.cache.getByShareId(shareId), null);
+      assert.equal(ctx.cache.db.prepare('SELECT COUNT(*) c FROM user_fetches').get().c, 0);
+    });
+  });
+
+  it('disabled mode deletes globally without auth', async () => {
+    await withApp('disabled', async (base, ctx) => {
+      const { id } = seed(ctx.cache, 'https://a.test/5', null);
+
+      const r = await fetch(`${base}/api/cache/${id}`, { method: 'DELETE' });
+
+      assert.equal(r.status, 200);
+      assert.deepEqual(await r.json(), { ok: true, id, scope: 'global' });
+    });
+  });
+
+  it('rejects an unparsable id with 400 before touching the cache', async () => {
+    await withApp('multi-user', async (base, ctx) => {
+      const r = await fetch(`${base}/api/cache/not-a-number`, { method: 'DELETE', headers: ctx.demoCookie });
+      assert.equal(r.status, 400);
+    });
+  });
+
+  it('still requires authentication', async () => {
+    await withApp('multi-user', async (base) => {
+      const r = await fetch(`${base}/api/cache/1`, { method: 'DELETE' });
+      assert.equal(r.status, 401);
+    });
+  });
+});
+
+describe('DELETE /api/cache scope', () => {
+  it('non-admin clears only their own history', async () => {
+    await withApp('multi-user', async (base, ctx) => {
+      seed(ctx.cache, 'https://a.test/6', ctx.demo.id);
+      seed(ctx.cache, 'https://a.test/7', ctx.demo.id);
+      seed(ctx.cache, 'https://a.test/8', ctx.admin.id);
+
+      const r = await fetch(`${base}/api/cache`, { method: 'DELETE', headers: ctx.demoCookie });
+
+      assert.equal(r.status, 200);
+      assert.deepEqual(await r.json(), { ok: true, scope: 'user', removed: 2 });
+      assert.deepEqual(ctx.cache.historyForUser(ctx.demo.id), []);
+      assert.equal(ctx.cache.historyForUser(ctx.admin.id).length, 1);
+      assert.equal(ctx.cache.db.prepare('SELECT COUNT(*) c FROM conversions').get().c, 3);
+    });
+  });
+
+  it('admin purges everything', async () => {
+    await withApp('multi-user', async (base, ctx) => {
+      seed(ctx.cache, 'https://a.test/9', ctx.demo.id);
+      seed(ctx.cache, 'https://a.test/10', ctx.admin.id);
+
+      const r = await fetch(`${base}/api/cache`, { method: 'DELETE', headers: ctx.adminCookie });
+
+      assert.equal(r.status, 200);
+      assert.deepEqual(await r.json(), { ok: true, scope: 'global', removed: 2 });
+      assert.equal(ctx.cache.db.prepare('SELECT COUNT(*) c FROM conversions').get().c, 0);
+      assert.equal(ctx.cache.db.prepare('SELECT COUNT(*) c FROM user_fetches').get().c, 0);
+    });
+  });
+});


### PR DESCRIPTION
Closes #49.

Two things were asked for: let a logged-in non-admin clear entries from their own history, and make self-registration switchable so a public demo instance can run in `multi-user` mode without collecting stranger accounts. Diagnosing the first turned up three more defects in the same code paths, fixed here as well.

## Delete scope instead of a 403

`adminOnly` is gone. Both delete routes now pick a *scope* rather than rejecting:

| Caller | `DELETE /api/cache/:id` | `DELETE /api/cache` |
|---|---|---|
| Non-admin | unlinks their own `user_fetches` row. Shared `conversions` row and `/s/:id` survive, other users unaffected | clears only their own history |
| Admin, or any caller when auth is `disabled`/unconfigured | drops the shared row (unchanged) | global purge (unchanged) |

Responses gained `scope: "user" \| "global"`, and delete-all gained `removed`. Existing status codes are unchanged: 400 on an unparsable id, 404 when nothing was deleted, 401 unauthenticated. The predicate `isGlobalScope` is character-for-character the condition the deleted middleware used, so admin semantics are preserved rather than reimplemented.

**Behaviour change worth a CHANGELOG line:** in `single-admin`/`multi-user`, a non-admin `DELETE /api/cache*` now answers `200` with `scope: "user"` instead of `403 {"error":"Admin required"}`.

## `PULLMD_ALLOW_SIGNUP`

Default on, so existing `multi-user` instances are unaffected. Only `false`/`0`/`no`/`off` closes registration, in which case the `/signup` routes are not mounted at all (404 for GET and POST, no user creatable), the login page drops its "create an account" link, and `/api/config` reports `signupOpen: false`.

`createAuth` exposes `allowSignup` (raw) and `signupOpen` (effective: `mode === 'multi-user' && allowSignup`). Only the effective value is read anywhere in production code.

This also fixes a live bug: `loginPage()` rendered the `/signup` link unconditionally, so in `single-admin` mode the login page linked to a route that does not exist.

## `create-user` in the admin CLI

`node scripts/admin.js create-user <email>` with a password prompt, so "registration closed" is not a state an operator cannot escape.

## Three defects found along the way

- **Orphaned `user_fetches` rows.** `pruneOld` runs on every `put()` and drops conversions older than 90 days, but never removed the matching fetch rows, and `countForUser` counts without the join that `historyPageForUser` uses. The archive therefore reported more entries than it could return, and the drift was permanent. Cleanup is now explicit SQL, plus a one-time sweep at `createCache`. A real FK with `ON DELETE CASCADE` was deliberately not used: enabling `PRAGMA foreign_keys` would start enforcing constraints across the oauth and session tables too. Measured cost of the sweep: 4 ms on a synthetic 50k/50k database.
- **`readPassword()` read nothing from non-TTY stdin.** `node:readline/promises`' `question()` returns a promise and ignores a callback, but the non-TTY fallback passed one. Any piped invocation printed the prompt and exited 0 having done nothing. This affected the pre-existing `reset-password` for as long as that command has existed. Guarded now by a child-process test.
- **`showError()` was invisible while the archive view was open.** `showArchive()` puts an inline `display:none` on the shared error element, which outranks the `.error.visible` class rule, and both archive delete buttons live inside that view. Two of the three delete paths would have kept failing silently.

## Frontend

All three delete paths surface failures through the existing `showError()`. The tooltip and the delete-all confirmation state their scope, derived from a predicate mirroring the server's. That flag is deliberately tri-state: `'unknown'` (`/api/me` answered nothing) is treated as a global delete, because claiming "global" for a delete that turns out to be scoped costs nothing while the reverse puts a harmless label on a destructive action.

## Verification

- `node --test`: **1091 pass / 0 fail** (1038 on `main`).
- `python3 markitdown-sidecar/test_limits.py` and `test_youtube.py`: 4 and 9 passed. These are not covered by `node --test`.
- Both new regression tests were proven non-vacuous by reverting the fix they guard and observing exactly that test fail.
- `create-user` smoke-tested end to end: creation via pipe, email trimmed and lowercased, duplicate in different case rejected, short password rejected, `reset-password` working via pipe, both accounts authenticating afterwards.

`package.json` is untouched; the version bump belongs to the release. Backward compatible for anyone setting none of the new variables, so this is a minor.

## Deliberately deferred

`db.transaction` construction placement in two admin-frequency cache methods, an idempotence test for the orphan sweep, `!auth` coverage for the delete-all route, and a symmetric override truth table. None affect behaviour; each was triaged as ship-as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfovDXWcqT7abP6EqFedk5