### PR TITLE
v3.10.0 — recipe append blocks, /api/status sidecar health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,11 @@ Self-hosters should consult [`MIGRATION.md`](./MIGRATION.md) when upgrading acro
 
 ## [Unreleased]
 
+<!-- Renamed to the dated version heading when the release is cut. -->
+
 ### Added
 
-- Site-Rezepte können strukturierte Daten aus eingebetteten JSON-Zustandsblöcken
-  (SSR-State von Single-Page-Frameworks) lesen und als JSON-Codeblock ans Ende des
-  Dokuments hängen. Neues optionales Rezeptfeld `append` mit Skript-Selektor,
-  Segment-Pfad, optionaler Feldprojektion und Zeilenlimit. Greift bei Seiten, deren
-  Zahlen nur noch als Diagramm gerendert werden und daher per CSS-Selektor nicht
-  erreichbar sind. Ausgabegröße ist fest gedeckelt.
+- **Site-recipes can now read structured data from embedded JSON state blocks.** Single-page frameworks render state as SSR blobs in `<script>` elements for the initial HTML. The new optional recipe field `append` extracts this data (by script selector and segment path, with optional field projection and row limit), serializes it as JSON, and appends it to the end of the document as a fenced code block. Output size is capped. The feature exists for pages where numerical data is only rendered as a chart and is therefore unreachable by CSS selectors.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Self-hosters should consult [`MIGRATION.md`](./MIGRATION.md) when upgrading acro
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- Site-Rezepte können strukturierte Daten aus eingebetteten JSON-Zustandsblöcken
+  (SSR-State von Single-Page-Frameworks) lesen und als JSON-Codeblock ans Ende des
+  Dokuments hängen. Neues optionales Rezeptfeld `append` mit Skript-Selektor,
+  Segment-Pfad, optionaler Feldprojektion und Zeilenlimit. Greift bei Seiten, deren
+  Zahlen nur noch als Diagramm gerendert werden und daher per CSS-Selektor nicht
+  erreichbar sind. Ausgabegröße ist fest gedeckelt.
+
+---
+
 ## [3.9.0] - 2026-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,13 @@ Self-hosters should consult [`MIGRATION.md`](./MIGRATION.md) when upgrading acro
 
 ### Added
 
+- **`GET /api/status` reports sidecar health for external monitoring.** It probes the `/health` endpoint of every configured extraction sidecar (trafilatura, Playwright, markitdown) in parallel and answers `200` when they all respond, `503` as soon as one is down, so a plain HTTP check catches it without keyword matching. A sidecar that was never configured counts as `not-configured`, not as a failure. Error reasons are a closed vocabulary (`unreachable`, `timeout`, `unhealthy`, `http <code>`, `misconfigured`) because the endpoint is public and must not echo internal hostnames. Results are cached for 5 seconds and concurrent callers share one round of probes. A broken sidecar does not take the service down, it silently degrades extraction quality — this makes that state observable.
+
 - **Site-recipes can now read structured data from embedded JSON state blocks.** Single-page frameworks render state as SSR blobs in `<script>` elements for the initial HTML. The new optional recipe field `append` extracts this data (by script selector and segment path, with optional field projection and row limit), serializes it as JSON, and appends it to the end of the document as a fenced code block. Output size is capped. The feature exists for pages where numerical data is only rendered as a chart and is therefore unreachable by CSS selectors.
+
+### Fixed
+
+- **`playwright-stealth` is now version-pinned** in `playwright-sidecar/requirements.txt`, like every other sidecar dependency. It was the only unpinned one, so any rebuild could have pulled an incompatible release into the image unnoticed.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Self-hosters should consult [`MIGRATION.md`](./MIGRATION.md) when upgrading acro
      there at the same time, or this heading renders as literal bracketed
      text. -->
 
+---
+
+## [3.10.0] - 2026-08-27
+
 ### Added
 
 - **`GET /api/status` reports sidecar health for external monitoring.** It probes the `/health` endpoint of every configured extraction sidecar (trafilatura, Playwright, markitdown) in parallel and answers `200` when they all respond, `503` as soon as one is down, so a plain HTTP check catches it without keyword matching. A sidecar that was never configured counts as `not-configured`, not as a failure. Error reasons are a closed vocabulary (`unreachable`, `timeout`, `unhealthy`, `http <code>`, `misconfigured`) because the endpoint is public and must not echo internal hostnames. Results are cached for 5 seconds and concurrent callers share one round of probes. A broken sidecar does not take the service down, it silently degrades extraction quality — this makes that state observable.
@@ -414,6 +418,7 @@ First public release. Self-hosted URL → Markdown service for humans and AI age
 
 ---
 
+[3.10.0]: https://github.com/AeternaLabsHQ/pullmd/releases/tag/v3.10.0
 [3.9.0]: https://github.com/AeternaLabsHQ/pullmd/releases/tag/v3.9.0
 [3.8.0]: https://github.com/AeternaLabsHQ/pullmd/releases/tag/v3.8.0
 [3.7.1]: https://github.com/AeternaLabsHQ/pullmd/releases/tag/v3.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ Self-hosters should consult [`MIGRATION.md`](./MIGRATION.md) when upgrading acro
 
 ## [Unreleased]
 
-<!-- Renamed to the dated version heading when the release is cut. -->
+<!-- Renamed to the dated version heading when the release is cut. Every other
+     version heading resolves through the reference-link list at the end of
+     this file - add the matching `[X.Y.Z]: .../releases/tag/vX.Y.Z` line
+     there at the same time, or this heading renders as literal bracketed
+     text. -->
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ doing nothing.
 | `/api/history`, `/api/archive`                                   |                 yes                  |
 | `DELETE /api/cache/:id`, `DELETE /api/cache`                     |                 yes                  |
 | `/api/stats`, `/api/storage`, `/api/config` (aggregate)          |                  no                  |
+| `/api/status`, `/api/recipes/status` (health)                    |                  no                  |
 
 Cache deletes are scoped to the caller. An admin (and every caller in
 `disabled` mode) removes the shared, URL-deduped cache row, which affects
@@ -501,6 +502,7 @@ for it.
 | `GET /api/stats`       | Extraction telemetry (sources, quality, latency). `?window=-7 days`.             |
 | `GET /api/config`      | Which optional tiers this instance has enabled (auth mode, markitdown, vision, STT, PDF OCR, YouTube). The PWA reads it to show or hide controls. |
 | `GET /api/recipes/status` | Which [site recipes](#site-recipes) loaded, which were rejected, and any frontmatter fields dropped by the allowlist. |
+| `GET /api/status`      | Health of the extraction sidecars (trafilatura, Playwright, markitdown). `200` when every configured sidecar answers, `503` when one is down. See [Monitoring](#monitoring). |
 | `POST /mcp`            | Streamable-HTTP MCP endpoint (3 tools: `read_url`, `get_share`, `list_recent`). |
 | `GET /pullmd.zip`      | Claude Code skill bundle, with this instance's URL baked in (`/web-reader.zip` redirects here). |
 | `GET /help`            | Bilingual user/agent setup guide.                                                |
@@ -628,6 +630,33 @@ Reported as [#41](https://github.com/AeternaLabsHQ/pullmd/issues/41), shipped in
 - **`/s/:id`** does the same on-demand refresh, so share links double as live endpoints.
 - Cache rows are pruned **90 days** after the last write. `/s/:id` hits keep the row alive (since they trigger refresh + write); read-only access does not extend the TTL.
 - If the source is unreachable on refresh, the last good snapshot is served — share links keep working even when the original URL dies.
+
+---
+
+## Monitoring
+
+`GET /api/status` reports whether the extraction sidecars are reachable:
+
+```json
+{
+  "ok": false,
+  "version": "3.9.0",
+  "services": {
+    "trafilatura": { "status": "ok", "latencyMs": 3 },
+    "playwright":  { "status": "down", "error": "unreachable" },
+    "markitdown":  { "status": "not-configured" }
+  }
+}
+```
+
+- `status` is `ok`, `down`, or `not-configured`. A sidecar you never configured is not a failure — self-hosting without Playwright or markitdown is a supported setup.
+- `error` is one of `unreachable`, `timeout`, `unhealthy` (answered `200` but reports itself broken), `http <code>`, or `misconfigured`. Deliberately a closed vocabulary: the endpoint is public and must not echo internal hostnames.
+- HTTP **`200`** when every configured sidecar answers, **`503`** when at least one is down, so a plain HTTP check catches it without keyword matching.
+- Results are cached for 5 seconds and concurrent callers share one round of probes, so polling it cannot amplify into internal traffic.
+
+Why it exists: a broken sidecar does not take PullMD down, it silently degrades extraction quality — pages that need a browser render come back near-empty while everything still answers `200`. Without an explicit check that can go unnoticed for a long time.
+
+**Uptime Kuma:** monitor type *HTTP(s)*, URL `https://<your-host>/api/status`, accepted status codes `200-299`. On an instance with authentication enabled the endpoint stays reachable without credentials.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ web pages exactly like v2, just with a cleaner body by default.
 - **Coverage guard** (3.7) - recovers pages where extraction kept only a sliver of the body; see [`PULLMD_COVERAGE_GUARD`](#configuration).
 - **Account controls** (3.8) - a non-admin can clear entries from their own history, self-registration can be closed with [`PULLMD_ALLOW_SIGNUP`](#configuration), and `scripts/admin.js create-user` creates accounts from the shell.
 - **Download button** (3.9) - the PWA saves a result as a `.md` file, named by the server via [`X-Suggested-Filename`](#response-headers) and optionally date-prefixed.
+- **[Sidecar health endpoint](#monitoring)** (3.10) - `GET /api/status` answers `503` when a configured sidecar stops responding, so a dead renderer shows up as an alert instead of quietly degrading extraction.
 
 ---
 

--- a/lib/append-data.js
+++ b/lib/append-data.js
@@ -59,6 +59,12 @@ export function resolveSegments(value, segments) {
       if (!Array.isArray(cur)) return undefined;
       cur = cur[seg];
     } else {
+      // A string segment indexes a plain object's OWN property only - never an
+      // array (arrays are for integer segments; a string segment would otherwise
+      // read exotic properties like `length`) and never an inherited property
+      // (`constructor`, `__proto__` and friends live on the prototype chain,
+      // not on the object itself).
+      if (Array.isArray(cur) || !Object.prototype.hasOwnProperty.call(cur, seg)) return undefined;
       cur = cur[seg];
     }
     if (cur === undefined) return undefined;
@@ -103,6 +109,11 @@ export function projectRows(value, fields, limit) {
 const BLOCK_BYTE_CAP = 64 * 1024;
 const DOC_BYTE_CAP = 128 * 1024;
 const MIN_USEFUL_BUDGET = 1024;
+
+/** German singular/plural for the row-count noun in notes and truncation text. */
+function rowNoun(n) {
+  return n === 1 ? 'Zeile' : 'Zeilen';
+}
 
 /** Load a cheerio instance from an HTML string, or pass through an existing one. */
 function toCheerio(htmlOr$) {
@@ -219,15 +230,20 @@ export function renderAppendBlocks(htmlOr$, specs) {
 
       const { body, kept, total } = serializeRows(rows, bodyBudget);
       if (kept === 0) {
-        notes.push(`${spec.title} (übersprungen, Budget erschöpft)`);
+        // Distinct from the bodyBudget < MIN_USEFUL_BUDGET case above: here the
+        // block still had a usable budget, but a single row's own serialized
+        // size exceeds it. Naming the real cause (an oversized row) instead of
+        // reusing the document-budget wording keeps operators from chasing the
+        // wrong lever.
+        notes.push(`${spec.title} (übersprungen, einzelner Datensatz zu groß)`);
         continue;
       }
 
-      const truncNote = kept < total ? `\n\nGekürzt: ${kept} von ${total} Zeilen ausgegeben.` : '';
+      const truncNote = kept < total ? `\n\nGekürzt: ${kept} von ${total} ${rowNoun(total)} ausgegeben.` : '';
       const block = `${opening}${body}${closing}${truncNote}`;
       parts.push(block);
       spent += Buffer.byteLength(block, 'utf8');
-      notes.push(kept < total ? `${spec.title} (${kept} von ${total} Zeilen)` : `${spec.title} (${kept} Zeilen)`);
+      notes.push(kept < total ? `${spec.title} (${kept} von ${total} ${rowNoun(total)})` : `${spec.title} (${kept} ${rowNoun(kept)})`);
     } catch (err) {
       // One bad block must never take down the others or the extraction.
       console.warn(`[append] "${spec?.title}" failed: ${err?.message ?? err}`);

--- a/lib/append-data.js
+++ b/lib/append-data.js
@@ -195,20 +195,36 @@ export function renderAppendBlocks(htmlOr$, specs) {
       }
 
       const budget = Math.min(BLOCK_BYTE_CAP, DOC_BYTE_CAP - spent);
-      if (budget < MIN_USEFUL_BUDGET) {
+
+      // The byte cap must bound the WHOLE assembled block, not just the row
+      // body: heading, fence markers and the truncation note all count. Reserve
+      // their worst-case size up front and only hand the remainder to the row
+      // serializer. `count` (the pre-truncation row total) is already known
+      // here, so the truncation note's max size can be computed exactly: for
+      // any 0 <= kept < total, digits(kept) <= digits(total), so sizing the
+      // note with `count` standing in for both numbers always overestimates.
+      const opening = `\n\n## ${spec.title}\n\n\`\`\`json\n`;
+      const closing = '\n```';
+      const maxTruncNote = `\n\nGekürzt: ${count} von ${count} Zeilen ausgegeben.`;
+      const chromeBytes = Buffer.byteLength(opening, 'utf8')
+        + Buffer.byteLength(closing, 'utf8')
+        + Buffer.byteLength(maxTruncNote, 'utf8');
+      const bodyBudget = budget - chromeBytes;
+
+      if (bodyBudget < MIN_USEFUL_BUDGET) {
         notes.push(`${spec.title} (übersprungen, Budget erschöpft)`);
         console.warn(`[append] "${spec.title}": document byte budget exhausted`);
         continue;
       }
 
-      const { body, kept, total } = serializeRows(rows, budget);
+      const { body, kept, total } = serializeRows(rows, bodyBudget);
       if (kept === 0) {
         notes.push(`${spec.title} (übersprungen, Budget erschöpft)`);
         continue;
       }
 
       const truncNote = kept < total ? `\n\nGekürzt: ${kept} von ${total} Zeilen ausgegeben.` : '';
-      const block = `\n\n## ${spec.title}\n\n\`\`\`json\n${body}\n\`\`\`${truncNote}`;
+      const block = `${opening}${body}${closing}${truncNote}`;
       parts.push(block);
       spent += Buffer.byteLength(block, 'utf8');
       notes.push(kept < total ? `${spec.title} (${kept} von ${total} Zeilen)` : `${spec.title} (${kept} Zeilen)`);

--- a/lib/append-data.js
+++ b/lib/append-data.js
@@ -1,0 +1,97 @@
+/**
+ * Append blocks: pull structured data out of an embedded JSON <script> and
+ * render it as a fenced JSON block at the end of the document.
+ *
+ * Site recipes increasingly face pages that render their numbers client-side
+ * from an SSR state blob (Angular `ng-state`, Next.js `__NEXT_DATA__`) and
+ * leave nothing addressable in the DOM but an SVG chart. `select.content`
+ * cannot reach those values; this module addresses the DATA instead of its
+ * presentation.
+ *
+ * Semantics are fixed and deliberate:
+ *
+ *  - Paths are ARRAYS OF SEGMENTS, not dot-paths. Real-world state blobs use
+ *    keys like `p_city_local/forecast` and full API URLs containing dots,
+ *    slashes, `?` and `=`. A segment array needs no escaping grammar.
+ *  - A string segment indexes an object, an integer segment indexes an array.
+ *    Arrays are NOT collapsed to their first element (unlike resolvePath in
+ *    jsonld.js) because the array is usually the target.
+ *  - An unresolved field omits its key rather than writing null.
+ *  - Nothing in here ever throws out: every failure resolves to null/empty so
+ *    the content pipeline is never affected.
+ */
+
+/**
+ * Parse the first script element matching `selector` as JSON.
+ * @param {import('cheerio').CheerioAPI} $
+ * @param {string} selector
+ * @returns {object|Array|null} null when absent, empty, or malformed
+ */
+export function parseJsonScript($, selector) {
+  let raw;
+  try {
+    raw = $(selector).first().text();
+  } catch {
+    return null; // invalid selector must never break extraction
+  }
+  if (!raw || !raw.trim()) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Walk a segment array into a parsed value.
+ * @param {*} value
+ * @param {Array<string|number>} segments
+ * @returns {*} undefined when any step fails to resolve
+ */
+export function resolveSegments(value, segments) {
+  if (value == null || !Array.isArray(segments) || segments.length === 0) return undefined;
+  let cur = value;
+  for (const seg of segments) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    if (typeof seg === 'number') {
+      if (!Array.isArray(cur)) return undefined;
+      cur = cur[seg];
+    } else {
+      cur = cur[seg];
+    }
+    if (cur === undefined) return undefined;
+  }
+  return cur;
+}
+
+/**
+ * Project a resolved value into output rows.
+ *
+ * With `fields`: a single object becomes a one-row list, non-object rows are
+ * skipped, each row is projected and renamed in field order.
+ * Without `fields`: the value passes through unchanged, arrays capped at limit.
+ *
+ * @param {*} value
+ * @param {Record<string, Array<string|number>>} [fields]
+ * @param {number} limit
+ * @returns {*}
+ */
+export function projectRows(value, fields, limit) {
+  if (value === undefined || value === null) return [];
+  if (!fields) {
+    return Array.isArray(value) ? value.slice(0, limit) : value;
+  }
+  const rows = Array.isArray(value) ? value : [value];
+  const out = [];
+  for (const row of rows) {
+    if (out.length >= limit) break;
+    if (row === null || typeof row !== 'object' || Array.isArray(row)) continue;
+    const projected = {};
+    for (const [name, segments] of Object.entries(fields)) {
+      const v = resolveSegments(row, segments);
+      if (v !== undefined) projected[name] = v;
+    }
+    out.push(projected);
+  }
+  return out;
+}

--- a/lib/append-data.js
+++ b/lib/append-data.js
@@ -21,6 +21,8 @@
  *    the content pipeline is never affected.
  */
 
+import * as cheerio from 'cheerio';
+
 /**
  * Parse the first script element matching `selector` as JSON.
  * @param {import('cheerio').CheerioAPI} $
@@ -94,4 +96,127 @@ export function projectRows(value, fields, limit) {
     out.push(projected);
   }
   return out;
+}
+
+/** Serialized-size caps. Deliberately NOT configurable: this is the only place
+ *  where a recipe could grow the output without bound. */
+const BLOCK_BYTE_CAP = 64 * 1024;
+const DOC_BYTE_CAP = 128 * 1024;
+const MIN_USEFUL_BUDGET = 1024;
+
+/** Load a cheerio instance from an HTML string, or pass through an existing one. */
+function toCheerio(htmlOr$) {
+  return typeof htmlOr$ === 'function' ? htmlOr$ : cheerio.load(htmlOr$);
+}
+
+/**
+ * Serialize rows as one JSON object per line inside a `[` / `]` envelope,
+ * dropping rows from the end until the result fits `budget` bytes.
+ *
+ * Uses a binary search over the row count rather than a fixed-percentage
+ * step: a coarse step can overshoot and leave the block well under its own
+ * cap, which then starves later blocks of document budget they should
+ * still have had. The search converges to the largest row count whose
+ * serialized body still fits, so the block uses as much of its budget as
+ * the row boundaries allow.
+ *
+ * @returns {{ body: string, kept: number, total: number }}
+ */
+function serializeRows(rows, budget) {
+  const list = Array.isArray(rows) ? rows : [rows];
+  const lines = list.map((r) => JSON.stringify(r));
+  const total = lines.length;
+  const bodyFor = (n) => `[\n${lines.slice(0, n).join(',\n')}\n]`;
+
+  let kept = total;
+  let body = bodyFor(kept);
+  if (Buffer.byteLength(body, 'utf8') > budget) {
+    let lo = 0; // largest row count confirmed to fit the budget
+    let hi = total; // smallest row count confirmed NOT to fit
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      if (Buffer.byteLength(bodyFor(mid), 'utf8') <= budget) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    kept = lo;
+    body = bodyFor(kept);
+  }
+  return { body, kept, total };
+}
+
+/**
+ * Render every append block of a recipe into markdown appended at document end.
+ *
+ * @param {string|import('cheerio').CheerioAPI} htmlOr$
+ * @param {Array<object>} specs  validated append block specs
+ * @returns {{ markdown: string, notes: string[] }} empty markdown when nothing resolved
+ */
+export function renderAppendBlocks(htmlOr$, specs) {
+  const empty = { markdown: '', notes: [] };
+  if (!Array.isArray(specs) || specs.length === 0) return empty;
+
+  let $;
+  try {
+    $ = toCheerio(htmlOr$);
+  } catch {
+    return empty;
+  }
+
+  const parsedByScript = new Map();
+  const parts = [];
+  const notes = [];
+  let spent = 0;
+
+  for (const spec of specs) {
+    try {
+      if (!parsedByScript.has(spec.script)) {
+        parsedByScript.set(spec.script, parseJsonScript($, spec.script));
+      }
+      const blob = parsedByScript.get(spec.script);
+      if (blob == null) {
+        console.warn(`[append] "${spec.title}": script ${spec.script} missing or not JSON`);
+        continue;
+      }
+
+      const resolved = resolveSegments(blob, spec.path);
+      if (resolved === undefined) {
+        console.warn(`[append] "${spec.title}": path did not resolve`);
+        continue;
+      }
+
+      const rows = projectRows(resolved, spec.fields, spec.limit);
+      const count = Array.isArray(rows) ? rows.length : 1;
+      if (count === 0) {
+        console.warn(`[append] "${spec.title}": resolved to zero rows`);
+        continue;
+      }
+
+      const budget = Math.min(BLOCK_BYTE_CAP, DOC_BYTE_CAP - spent);
+      if (budget < MIN_USEFUL_BUDGET) {
+        notes.push(`${spec.title} (übersprungen, Budget erschöpft)`);
+        console.warn(`[append] "${spec.title}": document byte budget exhausted`);
+        continue;
+      }
+
+      const { body, kept, total } = serializeRows(rows, budget);
+      if (kept === 0) {
+        notes.push(`${spec.title} (übersprungen, Budget erschöpft)`);
+        continue;
+      }
+
+      const truncNote = kept < total ? `\n\nGekürzt: ${kept} von ${total} Zeilen ausgegeben.` : '';
+      const block = `\n\n## ${spec.title}\n\n\`\`\`json\n${body}\n\`\`\`${truncNote}`;
+      parts.push(block);
+      spent += Buffer.byteLength(block, 'utf8');
+      notes.push(kept < total ? `${spec.title} (${kept} von ${total} Zeilen)` : `${spec.title} (${kept} Zeilen)`);
+    } catch (err) {
+      // One bad block must never take down the others or the extraction.
+      console.warn(`[append] "${spec?.title}" failed: ${err?.message ?? err}`);
+    }
+  }
+
+  return { markdown: parts.join(''), notes };
 }

--- a/lib/recipes.js
+++ b/lib/recipes.js
@@ -83,7 +83,13 @@ const PathSegment = z.union([z.string().min(1), z.number().int().min(0)]);
 // hang it on the end of the document as a fenced JSON block. Byte caps live in
 // lib/append-data.js and are deliberately not configurable from a recipe.
 const AppendBlockSchema = z.object({
-  title:  z.string().min(1).max(120),
+  // No line breaks: `title` is rendered behind a `## ` heading prefix in the
+  // fenced JSON block, and a bare newline would let the title carry its own
+  // fence-opener line, opening the code fence early and leaving the JSON body
+  // unfenced in the output markdown.
+  title:  z.string().min(1).max(120).regex(/^[^\r\n]+$/, {
+    message: 'title must not contain line breaks (would open a code fence early)',
+  }),
   script: z.string().min(1),
   path:   z.array(PathSegment).min(1),
   fields: z.record(RecipeFieldName, z.array(PathSegment).min(1)).optional(),

--- a/lib/recipes.js
+++ b/lib/recipes.js
@@ -38,15 +38,16 @@ const FrontmatterFieldSchema = z.object({
   { message: 'field must have exactly one of "jsonld" or "selector"' },
 );
 
-// Field names: letter-led, letters/digits/underscore/hyphen, ≤64 chars.
-const FrontmatterFieldName = z.string().regex(
+// Field names: letter-led, letters/digits/underscore/hyphen, <=64 chars.
+// Shared by recipe frontmatter fields and append-block field names.
+const RecipeFieldName = z.string().regex(
   /^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/,
-  { message: 'invalid frontmatter field name' },
+  { message: 'invalid recipe field name' },
 );
 
 const FrontmatterSchema = z.object({
   jsonld: z.object({ type: z.string().min(1) }).strict().optional(),
-  fields: z.record(FrontmatterFieldName, FrontmatterFieldSchema)
+  fields: z.record(RecipeFieldName, FrontmatterFieldSchema)
     .refine((o) => Object.keys(o).length > 0, { message: 'frontmatter.fields must be non-empty' }),
 }).strict().superRefine((v, ctx) => {
   const usesJsonld = Object.values(v.fields).some((f) => f && f.jsonld !== undefined);
@@ -72,6 +73,23 @@ const FrontmatterSchema = z.object({
   }
 });
 
+// A path into a parsed JSON blob, as an ARRAY OF SEGMENTS rather than a
+// dot-path: real state blobs use keys like `p_city_local/forecast` and whole
+// API URLs, so dots, slashes and query strings appear INSIDE keys. Segment
+// arrays need no escaping grammar. Integers index arrays.
+const PathSegment = z.union([z.string().min(1), z.number().int().min(0)]);
+
+// `append` blocks pull structured data out of an embedded JSON <script> and
+// hang it on the end of the document as a fenced JSON block. Byte caps live in
+// lib/append-data.js and are deliberately not configurable from a recipe.
+const AppendBlockSchema = z.object({
+  title:  z.string().min(1).max(120),
+  script: z.string().min(1),
+  path:   z.array(PathSegment).min(1),
+  fields: z.record(RecipeFieldName, z.array(PathSegment).min(1)).optional(),
+  limit:  z.number().int().min(1).max(1000).default(200),
+}).strict();
+
 export const RecipeSchema = z.object({
   name:       z.string().min(1),
   host:       z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]),
@@ -81,6 +99,7 @@ export const RecipeSchema = z.object({
   extractor:  z.enum(['readability', 'trafilatura', 'playwright']).optional(),
   fetch:      FetchSchema.default({}),
   frontmatter: FrontmatterSchema.optional(),
+  append:      z.array(AppendBlockSchema).default([]),
 }).strict();
 
 let cachedState = null;
@@ -233,6 +252,7 @@ export function mergeRecipes(recipes) {
     contentSelectors: [],
     extractor: undefined,
     fetch: {},
+    appendBlocks: [],
   };
   let fmFields = null;      // key-wise merge; later recipe wins on collision
   let fmJsonld;             // scalar last-wins
@@ -240,6 +260,7 @@ export function mergeRecipes(recipes) {
     result.preprocess = result.preprocess.concat(r.preprocess || []);
     result.removeSelectors = result.removeSelectors.concat(r.select?.remove || []);
     result.contentSelectors = result.contentSelectors.concat(r.select?.content || []);
+    result.appendBlocks = result.appendBlocks.concat(r.append || []);
     if (r.extractor !== undefined) result.extractor = r.extractor;
     if (r.fetch) {
       for (const key of ['render', 'wait_for', 'wait_timeout_ms', 'mobile_ua', 'pdf']) {

--- a/lib/status.js
+++ b/lib/status.js
@@ -1,0 +1,107 @@
+import { PULLMD_VERSION } from './distrib.js';
+
+const DEFAULT_TIMEOUT_MS = 2_000;
+const DEFAULT_TTL_MS = 5_000;
+
+// Every sidecar exposes GET /health next to its working endpoint, so the
+// configured URL is enough to reach both.
+const SIDECARS = [
+  { name: 'trafilatura', envVar: 'TRAFILATURA_URL' },
+  { name: 'playwright',  envVar: 'PLAYWRIGHT_URL' },
+  { name: 'markitdown',  envVar: 'MARKITDOWN_URL' },
+];
+
+/** Turn a sidecar's working endpoint into its health endpoint. */
+export function healthUrl(endpoint) {
+  const url = new URL(endpoint);
+  url.pathname = url.pathname.replace(/[^/]*$/, 'health');
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
+// Failure reasons stay a small closed vocabulary on purpose: /api/status is
+// public, and a raw error message would put the internal sidecar hostname
+// ("getaddrinfo ENOTFOUND playwright") into it.
+async function probe(endpoint, { fetch: fetchFn, timeoutMs }) {
+  let target;
+  try {
+    target = healthUrl(endpoint);
+  } catch {
+    return { status: 'down', error: 'misconfigured' };
+  }
+
+  const started = Date.now();
+  let res;
+  try {
+    res = await fetchFn(target, { signal: AbortSignal.timeout(timeoutMs) });
+  } catch (err) {
+    const timedOut = err?.name === 'TimeoutError' || err?.name === 'AbortError';
+    return { status: 'down', error: timedOut ? 'timeout' : 'unreachable' };
+  }
+  const latencyMs = Date.now() - started;
+
+  if (!res.ok) return { status: 'down', error: `http ${res.status}`, latencyMs };
+
+  // A sidecar that answers 200 but reports ok:false is up yet unusable - the
+  // Playwright sidecar does exactly that when Chromium failed to launch.
+  try {
+    const body = await res.json();
+    if (body && body.ok === false) return { status: 'down', error: 'unhealthy', latencyMs };
+  } catch {
+    // Not JSON. It answered, that is all this endpoint promises to check.
+  }
+  return { status: 'ok', latencyMs };
+}
+
+async function collect({ fetch: fetchFn, env, timeoutMs, version }) {
+  const entries = await Promise.all(SIDECARS.map(async ({ name, envVar }) => {
+    const endpoint = env[envVar];
+    if (!endpoint) return [name, { status: 'not-configured' }];
+    return [name, await probe(endpoint, { fetch: fetchFn, timeoutMs })];
+  }));
+
+  const services = Object.fromEntries(entries);
+  const ok = Object.values(services).every((svc) => svc.status !== 'down');
+  return { ok, version, services };
+}
+
+/**
+ * Build the /api/status probe. Results are cached briefly and concurrent
+ * callers share one round of probes, so a monitor (or a hammering client)
+ * cannot turn one public request into three internal ones each time.
+ *
+ * @param {object} [opts]
+ * @param {typeof fetch} [opts.fetch]  injectable for tests
+ * @param {object} [opts.env]          defaults to process.env (read per call)
+ * @param {number} [opts.timeoutMs]    per-sidecar probe timeout
+ * @param {number} [opts.ttlMs]        cache lifetime
+ * @param {() => number} [opts.now]    injectable clock
+ * @param {string} [opts.version]
+ * @returns {() => Promise<{ok: boolean, version: string, services: object}>}
+ */
+export function createStatusChecker({
+  fetch: fetchFn = globalThis.fetch,
+  env = process.env,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  ttlMs = DEFAULT_TTL_MS,
+  now = Date.now,
+  version = PULLMD_VERSION,
+} = {}) {
+  let cached = null;
+  let inflight = null;
+
+  return async function checkStatus() {
+    if (cached && now() - cached.at < ttlMs) return cached.value;
+    if (inflight) return inflight;
+
+    inflight = collect({ fetch: fetchFn, env, timeoutMs, version })
+      .then((value) => {
+        cached = { at: now(), value };
+        return value;
+      })
+      .finally(() => { inflight = null; });
+
+    return inflight;
+  };
+}

--- a/lib/web.js
+++ b/lib/web.js
@@ -477,23 +477,17 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
     } catch { /* extraction must never break the content pipeline */ }
   }
 
-  // Single exit point for this function. Keeping every return funnelled
-  // through one place means the recipe `append` blocks are attached
-  // consistently no matter which path decided the document's content.
+  // Single exit point for this function. It does NOT attach the append block
+  // to the markdown here - renderDecision() (called by extractWeb() after this
+  // function returns) measures result.markdown length to decide whether to
+  // fall back to Playwright, and a data block sitting there already would let
+  // a thin static extraction look long enough to skip that fallback on
+  // exactly the SPA pages this feature targets. Instead the block is stashed
+  // on the result for the caller to attach once the render decision is
+  // settled, via attachAppendBlock() below.
   const finish = (result) => {
-    if (!appendMd && appendNotes.length === 0) return result;
-    if (appendMd) {
-      result.markdown += appendMd;
-      // contentLength describes the OUTPUT, so it grows. quality deliberately
-      // does not: it judges how well extraction hit the page and drives
-      // renderDecision(), and a fat data block must not let a bad extraction
-      // hide from the Playwright fallback.
-      result.metadata.contentLength = result.markdown.trim().length;
-    }
-    if (appendNotes.length) {
-      const prev = result.metadata.extractorReason;
-      result.metadata.extractorReason =
-        (prev ? prev + ' | ' : '') + `append: ${appendNotes.join(', ')}`;
+    if (appendMd || appendNotes.length) {
+      result.append = { markdown: appendMd, notes: appendNotes };
     }
     return result;
   };
@@ -657,6 +651,40 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
     source,
     metadata,
   });
+}
+
+/**
+ * Attach a recipe `append` block stashed by convertWithReadability() (see
+ * `finish()` above) once the caller's render decision is settled. No-op when
+ * `result.append` is absent - which is every path that never called
+ * convertWithReadability (cloudflare markdown, markitdown, youtube, pdf-ocr,
+ * image/audio captioning) as well as recipes with no append blocks.
+ *
+ * Mirrors what `finish()` used to do directly: append the markdown, recompute
+ * `contentLength` from the OUTPUT (quality is deliberately left untouched -
+ * it drives renderDecision() and must reflect the extraction, not a data
+ * block glued on afterwards), and append `append: <notes>` to
+ * `extractorReason`, preserving any reason already there. Always deletes
+ * `result.append` afterward so the stash never leaks past this point (into
+ * callers, the HTTP layer, or the cache).
+ *
+ * @param {object} result  Output of convertWithReadability, possibly carrying `.append`
+ * @returns {object} the same result, mutated in place
+ */
+function attachAppendBlock(result) {
+  const append = result.append;
+  if (!append) return result;
+  delete result.append;
+  if (append.markdown) {
+    result.markdown += append.markdown;
+    result.metadata.contentLength = result.markdown.trim().length;
+  }
+  if (append.notes && append.notes.length) {
+    const prev = result.metadata.extractorReason;
+    result.metadata.extractorReason =
+      (prev ? prev + ' | ' : '') + `append: ${append.notes.join(', ')}`;
+  }
+  return result;
 }
 
 /**
@@ -887,9 +915,10 @@ export async function extractWeb(url, options = {}) {
   const result = await convertWithReadability(url, body, comments, statusCode, rawFetchFn, effectiveExtractor, recipe);
   emit('extracting', { source: result.source });
 
-  // Decide whether to render via Playwright sidecar
+  // Decide whether to render via Playwright sidecar. This MUST run before any
+  // recipe append block is attached to result.markdown - see attachAppendBlock().
   const decision = renderDecision(result, effectiveRender);
-  if (!decision.yes) return result;
+  if (!decision.yes) return attachAppendBlock(result);
 
   emit('rendering', { reason: decision.reason });
 
@@ -918,6 +947,9 @@ export async function extractWeb(url, options = {}) {
       rendered.source = 'playwright';
       rendered.metadata.extractorReason = renderReason;
     }
+    // Attach AFTER the extractorReason assignments above, so the append note
+    // lands after the render note instead of being overwritten by it.
+    attachAppendBlock(rendered);
     emit('extracting', { source: 'playwright' });
     return rendered;
   } catch (err) {
@@ -926,7 +958,7 @@ export async function extractWeb(url, options = {}) {
     const prevReason = result.metadata?.extractorReason || '';
     result.metadata.extractorReason =
       (prevReason ? prevReason + ' | ' : '') + `playwright fallback failed: ${errMsg}`;
-    return result;
+    return attachAppendBlock(result);
   }
 }
 
@@ -1034,5 +1066,8 @@ export async function extractHtml(html, options = {}) {
     ? extractor
     : recipe.extractor;
   const rawFetchFn = options.fetch || globalThis.fetch;
-  return convertWithReadability(url || null, stripDataUriImages(html), false, null, rawFetchFn, effectiveExtractor, recipe, filename);
+  // extractHtml() never goes through renderDecision() (there is no fetch, no
+  // Playwright fallback to protect), so the append block can attach right away.
+  const result = await convertWithReadability(url || null, stripDataUriImages(html), false, null, rawFetchFn, effectiveExtractor, recipe, filename);
+  return attachAppendBlock(result);
 }

--- a/lib/web.js
+++ b/lib/web.js
@@ -449,6 +449,11 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
   metadata.sourceUrl = url ?? null;
   metadata.statusCode = statusCode;
 
+  // Single exit point for this function. Task 4 hangs the recipe `append`
+  // blocks here; keeping every return funnelled through one place means a
+  // new output-shaping concern never has to touch three call sites again.
+  const finish = (result) => result;
+
   // Recipe-defined frontmatter fields (JSON-LD / CSS selectors) are computed from
   // the same HTML this pass extracts — after preprocess actions, and BEFORE
   // cleanDom strips <script> tags. On the two-pass pipeline the rendered pass
@@ -482,7 +487,7 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
     const markdown = nhm.translate(contentHtml);
     metadata.quality = qualityScore(markdown, { rawHtml: cleanedHtml });
     metadata.contentLength = markdown.trim().length;
-    return { markdown: formatHeader(title, url, date, filename) + markdown, title, source: 'readability', metadata };
+    return finish({ markdown: formatHeader(title, url, date, filename) + markdown, title, source: 'readability', metadata });
   }
 
   let recipeContentFellBack = null;
@@ -498,12 +503,12 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
       metadata.quality = qualityScore(selectedMd, { rawHtml: cleanedHtml });
       metadata.extractorReason = `recipe select.content (${recipe.contentSelectors.length} selector(s))`;
       metadata.contentLength = selectedMd.trim().length;
-      return {
+      return finish({
         markdown: formatHeader(title, url, date, filename) + selectedMd,
         title,
         source: 'recipe-content',
         metadata,
-      };
+      });
     }
     recipeContentFellBack = selectedMd.trim().length === 0
       ? 'matched nothing'
@@ -615,12 +620,12 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
     : extractorReason;
   metadata.contentLength = chosenMd.trim().length;
 
-  return {
+  return finish({
     markdown: formatHeader(title, url, date, filename) + chosenMd,
     title,
     source,
     metadata,
-  };
+  });
 }
 
 /**

--- a/lib/web.js
+++ b/lib/web.js
@@ -465,8 +465,9 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
 
   // Recipe `append` blocks: computed from the SAME html this pass extracts and
   // BEFORE cleanDom() strips <script> tags (see REMOVE_SELECTORS) - after that
-  // the state blob is gone. Rendered here, attached in finish() so every return
-  // path carries it. Never throws out into extraction.
+  // the state blob is gone. Rendered here, stashed on result.append by
+  // finish() below, and attached by the callers via attachAppendBlock() once
+  // the render decision is settled. Never throws out into extraction.
   let appendMd = '';
   let appendNotes = [];
   if (recipe?.appendBlocks?.length) {

--- a/lib/web.js
+++ b/lib/web.js
@@ -18,6 +18,7 @@ import { pickUserAgent, maybeRefreshUaPool } from './user-agent.js';
 import { preprocess } from './preprocess.js';
 import { matchRecipes, matchRecipesAgainst, applyPreprocessActions, mergeRecipes } from './recipes.js';
 import { extractRecipeFrontmatter } from './jsonld.js';
+import { renderAppendBlocks } from './append-data.js';
 import { convertViaMarkitdown, convertYoutubeViaSidecar } from './markitdown-client.js';
 import { isYoutubeUrl, normalizeYoutubeWatchUrl } from './youtube.js';
 import { captionImage } from './llm/vision.js';
@@ -449,11 +450,6 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
   metadata.sourceUrl = url ?? null;
   metadata.statusCode = statusCode;
 
-  // Single exit point for this function. Task 4 hangs the recipe `append`
-  // blocks here; keeping every return funnelled through one place means a
-  // new output-shaping concern never has to touch three call sites again.
-  const finish = (result) => result;
-
   // Recipe-defined frontmatter fields (JSON-LD / CSS selectors) are computed from
   // the same HTML this pass extracts — after preprocess actions, and BEFORE
   // cleanDom strips <script> tags. On the two-pass pipeline the rendered pass
@@ -466,6 +462,41 @@ async function convertWithReadability(url, html, comments, statusCode, fetchFn, 
       }
     } catch { /* extraction must never break the content pipeline */ }
   }
+
+  // Recipe `append` blocks: computed from the SAME html this pass extracts and
+  // BEFORE cleanDom() strips <script> tags (see REMOVE_SELECTORS) - after that
+  // the state blob is gone. Rendered here, attached in finish() so every return
+  // path carries it. Never throws out into extraction.
+  let appendMd = '';
+  let appendNotes = [];
+  if (recipe?.appendBlocks?.length) {
+    try {
+      const rendered = renderAppendBlocks(cleanedHtml, recipe.appendBlocks);
+      appendMd = rendered.markdown;
+      appendNotes = rendered.notes;
+    } catch { /* extraction must never break the content pipeline */ }
+  }
+
+  // Single exit point for this function. Keeping every return funnelled
+  // through one place means the recipe `append` blocks are attached
+  // consistently no matter which path decided the document's content.
+  const finish = (result) => {
+    if (!appendMd && appendNotes.length === 0) return result;
+    if (appendMd) {
+      result.markdown += appendMd;
+      // contentLength describes the OUTPUT, so it grows. quality deliberately
+      // does not: it judges how well extraction hit the page and drives
+      // renderDecision(), and a fat data block must not let a bad extraction
+      // hide from the Playwright fallback.
+      result.metadata.contentLength = result.markdown.trim().length;
+    }
+    if (appendNotes.length) {
+      const prev = result.metadata.extractorReason;
+      result.metadata.extractorReason =
+        (prev ? prev + ' | ' : '') + `append: ${appendNotes.join(', ')}`;
+    }
+    return result;
+  };
 
   // Recipe select.remove: apply to the shared DOM and re-serialize so ALL
   // downstream consumers see the removals — in particular the Trafilatura

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pullmd",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pullmd",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pullmd",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "type": "module",
   "main": "server.js",
   "license": "AGPL-3.0-or-later",

--- a/playwright-sidecar/requirements.txt
+++ b/playwright-sidecar/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.115.0
 uvicorn[standard]==0.32.0
 playwright==1.49.0
-playwright-stealth
+playwright-stealth==2.0.3

--- a/public/help.html
+++ b/public/help.html
@@ -632,6 +632,10 @@ Then: claude mcp list to verify.</pre>
             <td lang="de">Welche <a href="#recipes">Site-Recipes</a> geladen bzw. abgelehnt wurden.</td>
             <td lang="en">Which <a href="#recipes">site recipes</a> loaded or were rejected.</td>
           </tr>
+          <tr><td><code>GET /api/status</code></td>
+            <td lang="de">Erreichbarkeit der Extraktions-Sidecars (trafilatura, Playwright, markitdown). <code>200</code> wenn alle konfigurierten antworten, <code>503</code> sobald einer ausfällt — gedacht für externes Monitoring.</td>
+            <td lang="en">Health of the extraction sidecars (trafilatura, Playwright, markitdown). <code>200</code> when every configured one answers, <code>503</code> as soon as one is down — meant for external monitoring.</td>
+          </tr>
           <tr><td><code>POST /mcp</code></td>
             <td lang="de">MCP-Server (Streamable-HTTP, stateless), drei Tools.</td>
             <td lang="en">MCP server (Streamable HTTP, stateless), three tools.</td>

--- a/public/help.html
+++ b/public/help.html
@@ -327,6 +327,7 @@
         <li><strong>Coverage Guard</strong> (v3.7) - erkennt Extraktionen, die nur einen Bruchteil der Seite behalten haben, und holt den fehlenden Teil nach.</li>
         <li><strong>Kontenverwaltung</strong> (v3.8) - wer kein Admin ist, kann Einträge aus der eigenen Historie löschen; die Selbstregistrierung lässt sich schließen, und Konten lassen sich per CLI anlegen, siehe <a href="#auth">Authentifizierung</a>.</li>
         <li><strong>Download-Button</strong> (v3.9) - speichert das Ergebnis als <code>.md</code>-Datei; den Dateinamen schlägt der Server vor (<code>X-Suggested-Filename</code>), auf Wunsch mit Datums-Präfix.</li>
+        <li><strong>Sidecar-Health</strong> (v3.10) - <code>GET /api/status</code> meldet, ob die Extraktions-Sidecars antworten, und liefert <code>503</code> sobald einer ausfällt. Für externes Monitoring gedacht: ein toter Renderer nimmt den Dienst nicht runter, er verschlechtert nur still das Ergebnis.</li>
       </ul>
       <ul class="doc-list" lang="en">
         <li><strong>Hacker News</strong> (v3.1) - a dedicated pipeline for items, comment permalinks and listings, producing a clean nested comment tree instead of layout-table soup.</li>
@@ -338,6 +339,7 @@
         <li><strong>Coverage guard</strong> (v3.7) - detects extractions that kept only a sliver of the page and recovers the rest.</li>
         <li><strong>Account controls</strong> (v3.8) - a non-admin can delete entries from their own history, self-registration can be closed, and accounts can be created from the CLI, see <a href="#auth">Authentication</a>.</li>
         <li><strong>Download button</strong> (v3.9) - saves the result as a <code>.md</code> file, named by the server (<code>X-Suggested-Filename</code>), optionally with a date prefix.</li>
+        <li><strong>Sidecar health</strong> (v3.10) - <code>GET /api/status</code> reports whether the extraction sidecars respond, and answers <code>503</code> as soon as one is down. Meant for external monitoring: a dead renderer does not take the service down, it just quietly degrades the result.</li>
       </ul>
     </section>
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'pullmd-v30';
+const CACHE_NAME = 'pullmd-v31';
 const SHELL_URLS = [
   '/',
   '/index.html',

--- a/server.js
+++ b/server.js
@@ -10,10 +10,11 @@ import { buildFrontmatter, mergeMediaFrontmatter, mergeFrontmatter, validateFron
 import { queryExtract } from './lib/query-extract.js';
 import { suggestFilename } from './lib/filename.js';
 import { mcpHandler } from './lib/mcp.js';
-import { renderHelp, renderIndex, getSkillZip, publicUrlFor } from './lib/distrib.js';
+import { renderHelp, renderIndex, getSkillZip, publicUrlFor, PULLMD_VERSION } from './lib/distrib.js';
 import { getRecipeStatus, loadRecipes, applyRecipesInvalidation, computeRecipesHash } from './lib/recipes.js';
 import { assertUrlAllowed, SsrfError } from './lib/ssrf.js';
 import { ignoredModelEnvWarning } from './lib/llm/providers.js';
+import { createStatusChecker } from './lib/status.js';
 import path from 'node:path';
 import fs from 'node:fs';
 
@@ -113,6 +114,7 @@ export function createApp(overrides = {}) {
   const cache = overrides.cache || null;
   const auth = overrides.auth || null;
   const oauth = overrides.oauth || null;
+  const statusChecker = overrides.statusChecker || createStatusChecker();
   const disablePublicHistory = overrides.disablePublicHistory ?? readDisablePublicHistoryEnv();
   // Optional date prefix for the suggested download filename, e.g.
   // "YYYY-MM-DD-HH-mm-ss-". Unset = no prefix.
@@ -1028,6 +1030,25 @@ export function createApp(overrides = {}) {
       send('error', { message: String(err?.message ?? err) || 'Internal error' });
       res.end();
     }
+  });
+
+  // Sidecar health for external monitoring. Ungated like the other aggregate
+  // endpoints, because a monitor polls it without credentials, and it says no
+  // more about the instance than /api/config already does.
+  //
+  // 503 on degraded is deliberate: a plain HTTP monitor has to catch a dead
+  // sidecar too. The Playwright sidecar once crash-looped for eight weeks
+  // while extraction quietly fell back to empty results - nothing was watching
+  // because there was nothing to watch.
+  app.get('/api/status', async (req, res) => {
+    let status;
+    try {
+      status = await statusChecker();
+    } catch (err) {
+      console.warn('Status check failed:', err.message);
+      status = { ok: false, version: PULLMD_VERSION, services: {}, error: 'check-failed' };
+    }
+    res.status(status.ok ? 200 : 503).json(status);
   });
 
   app.get('/api/recipes/status', (req, res) => {

--- a/test/append-data.test.js
+++ b/test/append-data.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseJsonScript, resolveSegments, projectRows } from '../lib/append-data.js';
+import { parseJsonScript, resolveSegments, projectRows, renderAppendBlocks } from '../lib/append-data.js';
 import * as cheerio from 'cheerio';
 
 const wrap = (json, id = 'ng-state') =>
@@ -103,5 +103,82 @@ describe('projectRows', () => {
 
   it('applies limit to an array even without fields', () => {
     assert.equal(projectRows(rows, undefined, 1).length, 1);
+  });
+});
+
+const SPEC = {
+  title: '16-Tage-Trend',
+  script: '#ng-state',
+  path: ['p_city_local/forecast', 'longTerm'],
+  fields: { datum: ['date'], max_c: ['airTemperature', 'max', 'celsius'] },
+  limit: 200,
+};
+
+describe('renderAppendBlocks', () => {
+  it('renders a heading and a fenced json block with one row per line', () => {
+    const { markdown, notes } = renderAppendBlocks(wrap(JSON.stringify(BLOB)), [SPEC]);
+    assert.match(markdown, /\n## 16-Tage-Trend\n/);
+    assert.match(markdown, /```json\n\[\n/);
+    assert.match(markdown, /\n\]\n```/);
+    assert.ok(markdown.includes('{"datum":"2026-08-08","max_c":26}'));
+    assert.deepEqual(notes, ['16-Tage-Trend (2 Zeilen)']);
+  });
+
+  it('produces valid JSON inside the fence', () => {
+    const { markdown } = renderAppendBlocks(wrap(JSON.stringify(BLOB)), [SPEC]);
+    const body = markdown.split('```json\n')[1].split('\n```')[0];
+    assert.equal(JSON.parse(body).length, 2);
+  });
+
+  it('returns empty markdown for every failure mode without throwing', () => {
+    const ok = JSON.stringify(BLOB);
+    const cases = [
+      [wrap(ok), [{ ...SPEC, script: '#nope' }]],
+      [wrap('{ broken'), [SPEC]],
+      [wrap(ok), [{ ...SPEC, path: ['p_city_local/forecast', 'nope'] }]],
+      [wrap(JSON.stringify({ 'p_city_local/forecast': { longTerm: 'a string' } })), [SPEC]],
+      [wrap(ok), []],
+    ];
+    for (const [html, specs] of cases) {
+      const { markdown, notes } = renderAppendBlocks(html, specs);
+      assert.equal(markdown, '');
+      assert.deepEqual(notes, []);
+    }
+  });
+
+  it('parses the same script only once across several blocks', () => {
+    const original = JSON.parse;
+    let calls = 0;
+    JSON.parse = (...args) => { calls++; return original(...args); };
+    try {
+      renderAppendBlocks(wrap(JSON.stringify(BLOB)), [SPEC, { ...SPEC, title: 'Zweiter' }]);
+    } finally {
+      JSON.parse = original;
+    }
+    assert.equal(calls, 1, 'the blob must be parsed once, not once per block');
+  });
+
+  it('truncates at the per-block byte cap and says so beside the fence', () => {
+    const many = Array.from({ length: 4000 }, (_, i) => ({
+      date: `d${i}`, airTemperature: { max: { celsius: i } }, pad: 'x'.repeat(200),
+    }));
+    const html = wrap(JSON.stringify({ 'p_city_local/forecast': { longTerm: many } }));
+    const { markdown, notes } = renderAppendBlocks(html, [{ ...SPEC, limit: 1000, fields: undefined }]);
+    assert.ok(Buffer.byteLength(markdown, 'utf8') < 80 * 1024, 'must stay near the 64 KB cap');
+    assert.match(markdown, /Gekürzt: \d+ von \d+ Zeilen ausgegeben\./);
+    assert.match(notes[0], /von/);
+    const body = markdown.split('```json\n')[1].split('\n```')[0];
+    assert.ok(Array.isArray(JSON.parse(body)), 'truncated output must still be valid JSON');
+  });
+
+  it('skips a block when the document budget is exhausted', () => {
+    const many = Array.from({ length: 4000 }, (_, i) => ({ pad: 'y'.repeat(200), i }));
+    const html = wrap(JSON.stringify({ 'p_city_local/forecast': { longTerm: many } }));
+    const bulk = { ...SPEC, limit: 1000, fields: undefined };
+    const { markdown, notes } = renderAppendBlocks(html, [
+      { ...bulk, title: 'A' }, { ...bulk, title: 'B' }, { ...bulk, title: 'C' },
+    ]);
+    assert.ok(Buffer.byteLength(markdown, 'utf8') <= 132 * 1024, 'document cap must hold');
+    assert.ok(notes.some((n) => n.includes('übersprungen')), `expected a skip note, got ${JSON.stringify(notes)}`);
   });
 });

--- a/test/append-data.test.js
+++ b/test/append-data.test.js
@@ -181,4 +181,16 @@ describe('renderAppendBlocks', () => {
     assert.ok(Buffer.byteLength(markdown, 'utf8') <= 132 * 1024, 'document cap must hold');
     assert.ok(notes.some((n) => n.includes('übersprungen')), `expected a skip note, got ${JSON.stringify(notes)}`);
   });
+
+  it('keeps the assembled block within the 64 KB cap even at the schema max title length', () => {
+    const longTitle = 'T'.repeat(120); // recipe schema caps title at 120 chars
+    const many = Array.from({ length: 4000 }, (_, i) => ({
+      date: `d${i}`, airTemperature: { max: { celsius: i } }, pad: 'x'.repeat(200),
+    }));
+    const html = wrap(JSON.stringify({ 'p_city_local/forecast': { longTerm: many } }));
+    const { markdown } = renderAppendBlocks(html, [{ ...SPEC, title: longTitle, limit: 1000, fields: undefined }]);
+    assert.ok(Buffer.byteLength(markdown, 'utf8') <= 64 * 1024, 'the whole block, including heading and fence chrome, must respect the cap');
+    const body = markdown.split('```json\n')[1].split('\n```')[0];
+    assert.ok(Array.isArray(JSON.parse(body)), 'truncated output must still be valid JSON');
+  });
 });

--- a/test/append-data.test.js
+++ b/test/append-data.test.js
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseJsonScript, resolveSegments, projectRows } from '../lib/append-data.js';
+import * as cheerio from 'cheerio';
+
+const wrap = (json, id = 'ng-state') =>
+  `<html><head><script id="${id}" type="application/json">${json}</script></head><body></body></html>`;
+
+// Mirrors the real wetteronline blob: keys carry dots, slashes and query strings.
+const BLOB = {
+  'p_city_local/forecast': {
+    longTerm: [
+      { date: '2026-08-08', airTemperature: { max: { celsius: 26 }, min: { celsius: 11 } }, wind: { force: '2-3' } },
+      { date: '2026-08-09', airTemperature: { max: { celsius: 34 }, min: { celsius: 12 } }, wind: { force: '3' } },
+    ],
+  },
+  'https://api.example.com/v1?c=abc&release_version=XYZ': { days: [{ n: 1 }, { n: 2 }] },
+};
+
+describe('parseJsonScript', () => {
+  it('parses the first matching script element', () => {
+    const $ = cheerio.load(wrap(JSON.stringify(BLOB)));
+    const parsed = parseJsonScript($, '#ng-state');
+    assert.equal(parsed['p_city_local/forecast'].longTerm.length, 2);
+  });
+
+  it('returns null for a selector that matches nothing', () => {
+    const $ = cheerio.load(wrap(JSON.stringify(BLOB)));
+    assert.equal(parseJsonScript($, '#nope'), null);
+  });
+
+  it('returns null for malformed JSON instead of throwing', () => {
+    const $ = cheerio.load(wrap('{ this is not json'));
+    assert.equal(parseJsonScript($, '#ng-state'), null);
+  });
+});
+
+describe('resolveSegments', () => {
+  it('resolves a key that contains dots, slashes and a query string', () => {
+    const v = resolveSegments(BLOB, ['https://api.example.com/v1?c=abc&release_version=XYZ', 'days']);
+    assert.deepEqual(v, [{ n: 1 }, { n: 2 }]);
+  });
+
+  it('resolves a key containing a slash', () => {
+    const v = resolveSegments(BLOB, ['p_city_local/forecast', 'longTerm']);
+    assert.equal(v.length, 2);
+  });
+
+  it('indexes arrays with integer segments', () => {
+    assert.deepEqual(resolveSegments(BLOB, ['p_city_local/forecast', 'longTerm', 0, 'date']), '2026-08-08');
+  });
+
+  it('does NOT collapse arrays the way resolvePath does', () => {
+    const v = resolveSegments(BLOB, ['p_city_local/forecast', 'longTerm']);
+    assert.ok(Array.isArray(v), 'the array itself must survive, not its first element');
+  });
+
+  it('returns undefined for a path that runs into nothing', () => {
+    assert.equal(resolveSegments(BLOB, ['p_city_local/forecast', 'nope']), undefined);
+    assert.equal(resolveSegments(BLOB, ['p_city_local/forecast', 'longTerm', 99]), undefined);
+    assert.equal(resolveSegments(null, ['a']), undefined);
+  });
+});
+
+describe('projectRows', () => {
+  const rows = BLOB['p_city_local/forecast'].longTerm;
+  const fields = {
+    datum: ['date'],
+    max_c: ['airTemperature', 'max', 'celsius'],
+    wind: ['wind', 'force'],
+  };
+
+  it('projects and renames in field order', () => {
+    const out = projectRows(rows, fields, 200);
+    assert.deepEqual(out[0], { datum: '2026-08-08', max_c: 26, wind: '2-3' });
+    assert.deepEqual(Object.keys(out[0]), ['datum', 'max_c', 'wind']);
+  });
+
+  it('omits the key when a field does not resolve, instead of writing null', () => {
+    const out = projectRows([{ date: 'x' }], fields, 200);
+    assert.deepEqual(out[0], { datum: 'x' });
+    assert.ok(!('max_c' in out[0]));
+  });
+
+  it('normalizes a single object into a one-row list', () => {
+    const out = projectRows({ date: 'solo' }, { datum: ['date'] }, 200);
+    assert.deepEqual(out, [{ datum: 'solo' }]);
+  });
+
+  it('skips non-object rows when fields are set', () => {
+    const out = projectRows(['a', 42, { date: 'keep' }], { datum: ['date'] }, 200);
+    assert.deepEqual(out, [{ datum: 'keep' }]);
+  });
+
+  it('applies limit', () => {
+    assert.equal(projectRows(rows, fields, 1).length, 1);
+  });
+
+  it('passes the subtree through unchanged when fields are absent', () => {
+    const out = projectRows(rows, undefined, 200);
+    assert.deepEqual(out, rows);
+  });
+
+  it('applies limit to an array even without fields', () => {
+    assert.equal(projectRows(rows, undefined, 1).length, 1);
+  });
+});

--- a/test/append-data.test.js
+++ b/test/append-data.test.js
@@ -60,6 +60,19 @@ describe('resolveSegments', () => {
     assert.equal(resolveSegments(BLOB, ['p_city_local/forecast', 'longTerm', 99]), undefined);
     assert.equal(resolveSegments(null, ['a']), undefined);
   });
+
+  it('never resolves an inherited property such as "constructor" or "__proto__"', () => {
+    assert.equal(resolveSegments({ a: 1 }, ['constructor']), undefined);
+    assert.equal(resolveSegments({ a: 1 }, ['__proto__']), undefined);
+    assert.equal(resolveSegments({ a: { b: 1 } }, ['a', 'constructor']), undefined);
+  });
+
+  it('never resolves a string segment against an array (e.g. "length")', () => {
+    const arr = ['x', 'y', 'z'];
+    assert.equal(resolveSegments(arr, ['length']), undefined);
+    // Even a numeric-looking string is rejected - arrays are for integer segments only.
+    assert.equal(resolveSegments(arr, ['0']), undefined);
+  });
 });
 
 describe('projectRows', () => {
@@ -179,7 +192,32 @@ describe('renderAppendBlocks', () => {
       { ...bulk, title: 'A' }, { ...bulk, title: 'B' }, { ...bulk, title: 'C' },
     ]);
     assert.ok(Buffer.byteLength(markdown, 'utf8') <= 132 * 1024, 'document cap must hold');
-    assert.ok(notes.some((n) => n.includes('übersprungen')), `expected a skip note, got ${JSON.stringify(notes)}`);
+    // The genuine document-budget-exhaustion note names the budget as the cause.
+    assert.ok(notes.includes('C (übersprungen, Budget erschöpft)'), `expected a budget-exhausted note, got ${JSON.stringify(notes)}`);
+  });
+
+  it('names an oversized single row as its own cause, distinct from document budget exhaustion', () => {
+    // A single row whose own serialized size already exceeds the per-block
+    // budget - reached with plenty of document budget still available (this
+    // is the first and only block), so `kept === 0` here is NOT the document
+    // budget running out. The note must say so instead of blaming the budget.
+    const html = wrap(JSON.stringify({
+      'p_city_local/forecast': { longTerm: [{ pad: 'z'.repeat(70000) }] },
+    }));
+    const spec = { title: 'Huge', script: '#ng-state', path: ['p_city_local/forecast', 'longTerm'], limit: 1 };
+    const { markdown, notes } = renderAppendBlocks(html, [spec]);
+    assert.equal(markdown, '');
+    assert.deepEqual(notes, ['Huge (übersprungen, einzelner Datensatz zu groß)']);
+    // The two skip reasons must never share wording - an operator reading the
+    // note needs to know which lever to pull.
+    assert.notEqual(notes[0], 'Huge (übersprungen, Budget erschöpft)');
+  });
+
+  it('uses the singular "Zeile" when exactly one row is kept', () => {
+    const html = wrap(JSON.stringify({ 'p_city_local/forecast': { longTerm: [BLOB['p_city_local/forecast'].longTerm[0]] } }));
+    const { markdown, notes } = renderAppendBlocks(html, [SPEC]);
+    assert.deepEqual(notes, ['16-Tage-Trend (1 Zeile)']);
+    assert.ok(!markdown.includes('1 Zeilen'), 'must not say "1 Zeilen"');
   });
 
   it('keeps the assembled block within the 64 KB cap even at the schema max title length', () => {

--- a/test/recipes-append.test.js
+++ b/test/recipes-append.test.js
@@ -40,9 +40,23 @@ describe('recipe append schema', () => {
     assert.throws(() => parse([block({ title: 'x'.repeat(121) })]));
   });
 
+  it('accepts a title of exactly 120 characters', () => {
+    const title = 'x'.repeat(120);
+    assert.equal(parse([block({ title })]).append[0].title, title);
+  });
+
+  it('rejects an empty title', () => {
+    assert.throws(() => parse([block({ title: '' })]));
+  });
+
   it('rejects limit outside 1..1000', () => {
     assert.throws(() => parse([block({ limit: 0 })]));
     assert.throws(() => parse([block({ limit: 1001 })]));
+  });
+
+  it('accepts limit at the 1..1000 boundaries', () => {
+    assert.equal(parse([block({ limit: 1 })]).append[0].limit, 1);
+    assert.equal(parse([block({ limit: 1000 })]).append[0].limit, 1000);
   });
 
   it('rejects an unknown key inside a block', () => {

--- a/test/recipes-append.test.js
+++ b/test/recipes-append.test.js
@@ -1,0 +1,69 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { RecipeSchema, mergeRecipes } from '../lib/recipes.js';
+
+const block = (over = {}) => ({
+  title: 'Trend',
+  script: '#ng-state',
+  path: ['a/b', 'rows'],
+  ...over,
+});
+
+const parse = (append) => RecipeSchema.parse({ name: 't', host: 'example.com', append });
+
+describe('recipe append schema', () => {
+  it('defaults append to an empty array', () => {
+    assert.deepEqual(RecipeSchema.parse({ name: 't', host: 'example.com' }).append, []);
+  });
+
+  it('accepts a block and defaults limit to 200', () => {
+    const r = parse([block()]);
+    assert.equal(r.append.length, 1);
+    assert.equal(r.append[0].limit, 200);
+  });
+
+  it('accepts integer path segments', () => {
+    assert.deepEqual(parse([block({ path: ['days', 0, 'hours'] })]).append[0].path, ['days', 0, 'hours']);
+  });
+
+  it('accepts a fields map of segment arrays', () => {
+    const r = parse([block({ fields: { max_c: ['t', 'max'] } })]);
+    assert.deepEqual(r.append[0].fields.max_c, ['t', 'max']);
+  });
+
+  it('rejects an empty path', () => {
+    assert.throws(() => parse([block({ path: [] })]));
+  });
+
+  it('rejects a missing title and an over-long one', () => {
+    assert.throws(() => parse([block({ title: undefined })]));
+    assert.throws(() => parse([block({ title: 'x'.repeat(121) })]));
+  });
+
+  it('rejects limit outside 1..1000', () => {
+    assert.throws(() => parse([block({ limit: 0 })]));
+    assert.throws(() => parse([block({ limit: 1001 })]));
+  });
+
+  it('rejects an unknown key inside a block', () => {
+    assert.throws(() => parse([block({ format: 'table' })]));
+  });
+
+  it('rejects an invalid field name', () => {
+    assert.throws(() => parse([block({ fields: { '1bad': ['x'] } })]));
+  });
+});
+
+describe('mergeRecipes append', () => {
+  it('concatenates append blocks across matching recipes in order', () => {
+    const merged = mergeRecipes([
+      parse([block({ title: 'A' })]),
+      parse([block({ title: 'B' })]),
+    ]);
+    assert.deepEqual(merged.appendBlocks.map((b) => b.title), ['A', 'B']);
+  });
+
+  it('yields an empty list when no recipe defines append', () => {
+    assert.deepEqual(mergeRecipes([]).appendBlocks, []);
+  });
+});

--- a/test/recipes-append.test.js
+++ b/test/recipes-append.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { RecipeSchema, mergeRecipes } from '../lib/recipes.js';
+import { extractHtml } from '../lib/web.js';
 
 const block = (over = {}) => ({
   title: 'Trend',
@@ -79,5 +80,86 @@ describe('mergeRecipes append', () => {
 
   it('yields an empty list when no recipe defines append', () => {
     assert.deepEqual(mergeRecipes([]).appendBlocks, []);
+  });
+});
+
+const PROSE = 'This paragraph is deliberately long enough that the recipe-selected body clears the minimum length floor on its own, without help from any of the surrounding blocks on the page. The floor exists to catch selectors that have gone stale after a site redesign.';
+
+const STATE = JSON.stringify({
+  'p_city_local/forecast': {
+    longTerm: [
+      { date: '2026-08-08', t: { max: 26 } },
+      { date: '2026-08-09', t: { max: 34 } },
+    ],
+  },
+});
+
+const PAGE = `<html><head><title>Doc</title>
+  <script id="ng-state" type="application/json">${STATE}</script></head><body>
+  <div class="lead"><p>LEAD ${PROSE}</p></div>
+</body></html>`;
+
+const APPEND = [{
+  title: 'Trend',
+  script: '#ng-state',
+  path: ['p_city_local/forecast', 'longTerm'],
+  fields: { datum: ['date'], max_c: ['t', 'max'] },
+}];
+
+const recipeWith = (extra) => RecipeSchema.parse({
+  name: 'append-it', host: 'example.com', append: APPEND, ...extra,
+});
+
+describe('append blocks in the extraction pipeline', () => {
+  it('appends the block on the recipe-content path', async () => {
+    const r = await extractHtml(PAGE, {
+      url: 'https://example.com/a',
+      recipes: [recipeWith({ select: { content: ['.lead'] } })],
+      extractor: 'readability',
+    });
+    assert.equal(r.source, 'recipe-content');
+    assert.ok(r.markdown.includes('LEAD'), 'body must still be there');
+    assert.match(r.markdown, /## Trend\n\n```json\n/);
+    assert.ok(r.markdown.trimEnd().endsWith('```'), 'block must sit at the very end');
+    assert.ok(r.markdown.includes('{"datum":"2026-08-08","max_c":26}'));
+    assert.match(r.metadata.extractorReason, /append: Trend \(2 Zeilen\)/);
+  });
+
+  it('appends the block on the readability path too', async () => {
+    const r = await extractHtml(PAGE, {
+      url: 'https://example.com/a',
+      recipes: [recipeWith({})],
+      extractor: 'readability',
+    });
+    assert.notEqual(r.source, 'recipe-content');
+    assert.match(r.markdown, /## Trend\n/);
+  });
+
+  it('leaves quality untouched but grows contentLength', async () => {
+    const opts = { url: 'https://example.com/a', extractor: 'readability' };
+    const plain = await extractHtml(PAGE, { ...opts, recipes: [RecipeSchema.parse({ name: 'n', host: 'example.com' })] });
+    const withBlock = await extractHtml(PAGE, { ...opts, recipes: [recipeWith({})] });
+    assert.equal(withBlock.metadata.quality, plain.metadata.quality);
+    assert.ok(withBlock.metadata.contentLength > plain.metadata.contentLength);
+  });
+
+  it('changes nothing when the recipe has no append blocks', async () => {
+    const r = await extractHtml(PAGE, {
+      url: 'https://example.com/a',
+      recipes: [RecipeSchema.parse({ name: 'n', host: 'example.com' })],
+      extractor: 'readability',
+    });
+    assert.ok(!r.markdown.includes('```json'));
+    assert.ok(!/append:/.test(r.metadata.extractorReason || ''));
+  });
+
+  it('degrades to the plain document when the path is stale', async () => {
+    const stale = RecipeSchema.parse({
+      name: 'stale', host: 'example.com',
+      append: [{ ...APPEND[0], path: ['p_city_local/forecast', 'gone'] }],
+    });
+    const r = await extractHtml(PAGE, { url: 'https://example.com/a', recipes: [stale], extractor: 'readability' });
+    assert.ok(r.markdown.includes('LEAD'));
+    assert.ok(!r.markdown.includes('```json'));
   });
 });

--- a/test/recipes-append.test.js
+++ b/test/recipes-append.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { RecipeSchema, mergeRecipes } from '../lib/recipes.js';
-import { extractHtml } from '../lib/web.js';
+import { extractHtml, extractWeb } from '../lib/web.js';
 
 const block = (over = {}) => ({
   title: 'Trend',
@@ -161,5 +161,56 @@ describe('append blocks in the extraction pipeline', () => {
     const r = await extractHtml(PAGE, { url: 'https://example.com/a', recipes: [stale], extractor: 'readability' });
     assert.ok(r.markdown.includes('LEAD'));
     assert.ok(!r.markdown.includes('```json'));
+  });
+});
+
+describe('append blocks do not leak into the render decision', () => {
+  // The static extraction here is deliberately thin: forcing extractor=trafilatura
+  // with no sidecar configured always produces an extractorReason containing
+  // "fell back to ..." (see convertWithReadability), and the body is short
+  // enough that the base result.markdown (header + body, WITHOUT the append
+  // block) stays under the 500-char renderDecision floor. quality is kept
+  // >=0.5 (article tag + heading + a healthy markdown/rawHtml ratio) so the
+  // "low quality" trigger cannot also explain a render - only the "thin (<500c)"
+  // trigger can. The append block itself is sized well past 500 chars, so if
+  // it were attached to result.markdown BEFORE renderDecision ran, the "thin"
+  // trigger would falsely read as satisfied and skip the Playwright call.
+  const rows = [];
+  for (let i = 0; i < 20; i++) {
+    rows.push({ date: `2026-08-${String(i + 1).padStart(2, '0')}`, t: { max: 20 + i } });
+  }
+  const STATE = JSON.stringify({ 'p_city_local/forecast': { longTerm: rows } });
+  const THIN_PAGE = `<html><head><title>Doc</title>
+    <script id="ng-state" type="application/json">${STATE}</script></head><body>
+    <article><h2>Heading</h2><p>Some short paragraph text here for context.</p></article>
+  </body></html>`;
+
+  const recipe = RecipeSchema.parse({
+    name: 'thin-append', host: 'example.com',
+    append: [{
+      title: 'Trend', script: '#ng-state',
+      path: ['p_city_local/forecast', 'longTerm'],
+      fields: { datum: ['date'], max_c: ['t', 'max'] },
+    }],
+  });
+
+  const fetchHtml = (html) => async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: (k) => (k.toLowerCase() === 'content-type' ? 'text/html; charset=utf-8' : null) },
+    text: async () => html,
+  });
+
+  it('still calls the Playwright render client when the append block alone would push the result over the length floor', async () => {
+    let renderCalled = false;
+    const result = await extractWeb('https://example.com/thin', {
+      fetch: fetchHtml(THIN_PAGE),
+      extractor: 'trafilatura',
+      recipes: [recipe],
+      renderClient: async () => { renderCalled = true; return THIN_PAGE; },
+    });
+    assert.ok(renderCalled, 'the append block must not hide a thin static extraction from the render decision');
+    assert.ok(result.metadata.quality >= 0.5, 'test setup check: quality must not be the reason a render happens');
+    assert.match(result.markdown, /## Trend\n/, 'the append block must still end up in the final markdown');
   });
 });

--- a/test/recipes-append.test.js
+++ b/test/recipes-append.test.js
@@ -50,6 +50,13 @@ describe('recipe append schema', () => {
     assert.throws(() => parse([block({ title: '' })]));
   });
 
+  it('rejects a title containing a line break', () => {
+    // A newline lets the title carry its own fence-opener line, opening the
+    // code fence early and leaving the JSON body unfenced in the output.
+    assert.throws(() => parse([block({ title: 'Foo\n```\nevil' })]));
+    assert.throws(() => parse([block({ title: 'Foo\r\nbar' })]));
+  });
+
   it('rejects limit outside 1..1000', () => {
     assert.throws(() => parse([block({ limit: 0 })]));
     assert.throws(() => parse([block({ limit: 1001 })]));
@@ -212,5 +219,31 @@ describe('append blocks do not leak into the render decision', () => {
     assert.ok(renderCalled, 'the append block must not hide a thin static extraction from the render decision');
     assert.ok(result.metadata.quality >= 0.5, 'test setup check: quality must not be the reason a render happens');
     assert.match(result.markdown, /## Trend\n/, 'the append block must still end up in the final markdown');
+  });
+});
+
+describe('append blocks on the comments return path', () => {
+  // extractHtml() hardcodes comments = false, so this early-return branch of
+  // convertWithReadability (the `if (comments) { ... return finish(...); }`
+  // path) is only reachable through extractWeb() with comments: true - which
+  // is exactly how GET /api?comments=true&url=<non-Reddit URL> reaches it.
+  const fetchHtml = async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: (k) => (k.toLowerCase() === 'content-type' ? 'text/html; charset=utf-8' : null) },
+    text: async () => PAGE,
+  });
+
+  it('still carries the append block when comments=true short-circuits to the comments branch', async () => {
+    const result = await extractWeb('https://example.com/a', {
+      fetch: fetchHtml,
+      recipes: [recipeWith({})],
+      comments: true,
+      render: 'skip',
+    });
+    assert.equal(result.source, 'readability');
+    assert.match(result.markdown, /## Trend\n\n```json\n/);
+    assert.ok(result.markdown.includes('{"datum":"2026-08-08","max_c":26}'));
+    assert.match(result.metadata.extractorReason, /append: Trend \(2 Zeilen\)/);
   });
 });

--- a/test/status-endpoint.test.js
+++ b/test/status-endpoint.test.js
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createApp } from '../server.js';
+
+async function get(app, path) {
+  const server = app.listen(0);
+  try {
+    const res = await fetch(`http://localhost:${server.address().port}${path}`);
+    return { status: res.status, body: await res.json() };
+  } finally {
+    server.close();
+  }
+}
+
+const HEALTHY = {
+  ok: true,
+  version: '9.9.9',
+  services: {
+    trafilatura: { status: 'ok', latencyMs: 2 },
+    playwright: { status: 'ok', latencyMs: 3 },
+    markitdown: { status: 'not-configured' },
+  },
+};
+
+describe('GET /api/status', () => {
+  it('returns 200 and the service map when everything is healthy', async () => {
+    const app = createApp({ cache: null, statusChecker: async () => HEALTHY });
+    const res = await get(app, '/api/status');
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.equal(res.body.version, '9.9.9');
+    assert.equal(res.body.services.playwright.status, 'ok');
+  });
+
+  it('returns 503 when a configured sidecar is down', async () => {
+    // The whole point of the endpoint: a plain HTTP monitor must catch this,
+    // not just a keyword monitor.
+    const degraded = {
+      ...HEALTHY,
+      ok: false,
+      services: { ...HEALTHY.services, playwright: { status: 'down', error: 'unreachable' } },
+    };
+    const app = createApp({ cache: null, statusChecker: async () => degraded });
+    const res = await get(app, '/api/status');
+
+    assert.equal(res.status, 503);
+    assert.equal(res.body.ok, false);
+    assert.equal(res.body.services.playwright.error, 'unreachable');
+  });
+
+  it('reports 503 rather than 500 when the check itself throws', async () => {
+    const app = createApp({
+      cache: null,
+      statusChecker: async () => { throw new Error('boom'); },
+    });
+    const res = await get(app, '/api/status');
+
+    assert.equal(res.status, 503);
+    assert.equal(res.body.ok, false);
+  });
+
+  it('is reachable without authentication', async () => {
+    // Monitors poll it unauthenticated; auth-mode instances must not gate it.
+    const app = createApp({
+      cache: null,
+      statusChecker: async () => HEALTHY,
+      auth: {
+        mode: 'single-admin',
+        middleware: () => (req, res, next) => next(),
+        mountAuthRoutes: () => {},
+        requireAuth: () => (req, res) => res.status(401).json({ error: 'unauthorized' }),
+      },
+    });
+    const res = await get(app, '/api/status');
+
+    assert.equal(res.status, 200);
+  });
+});

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -1,0 +1,211 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { healthUrl, createStatusChecker } from '../lib/status.js';
+
+const ENV = {
+  TRAFILATURA_URL: 'http://trafilatura:8001/extract',
+  PLAYWRIGHT_URL: 'http://playwright:8002/render',
+  MARKITDOWN_URL: 'http://markitdown:8003/convert',
+};
+
+// Minimal Response stand-in: the checker only reads ok/status/json().
+const reply = (body = { ok: true }, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+});
+
+function fakeFetch(handler) {
+  const calls = [];
+  const fn = async (url, opts) => {
+    calls.push(url);
+    return handler(url, opts);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('healthUrl', () => {
+  it('swaps the endpoint path segment for /health', () => {
+    assert.equal(healthUrl('http://playwright:8002/render'), 'http://playwright:8002/health');
+    assert.equal(healthUrl('http://trafilatura:8001/extract'), 'http://trafilatura:8001/health');
+    assert.equal(healthUrl('http://markitdown:8003/convert'), 'http://markitdown:8003/health');
+  });
+
+  it('keeps a nested base path', () => {
+    assert.equal(healthUrl('http://host/sidecar/v1/render'), 'http://host/sidecar/v1/health');
+  });
+
+  it('handles a trailing slash and a bare origin', () => {
+    assert.equal(healthUrl('http://host:8002/'), 'http://host:8002/health');
+    assert.equal(healthUrl('http://host:8002'), 'http://host:8002/health');
+  });
+
+  it('drops query and hash', () => {
+    assert.equal(healthUrl('http://host/render?debug=1#x'), 'http://host/health');
+  });
+});
+
+describe('createStatusChecker', () => {
+  it('reports every configured sidecar as ok when all answer', async () => {
+    const fetch = fakeFetch(() => reply());
+    const status = await createStatusChecker({ fetch, env: ENV })();
+
+    assert.equal(status.ok, true);
+    assert.deepEqual(Object.keys(status.services), ['trafilatura', 'playwright', 'markitdown']);
+    for (const svc of Object.values(status.services)) {
+      assert.equal(svc.status, 'ok');
+      assert.equal(typeof svc.latencyMs, 'number');
+    }
+    assert.equal(typeof status.version, 'string');
+  });
+
+  it('probes the /health path, not the working endpoint', async () => {
+    const fetch = fakeFetch(() => reply());
+    await createStatusChecker({ fetch, env: ENV })();
+
+    assert.deepEqual(fetch.calls.sort(), [
+      'http://markitdown:8003/health',
+      'http://playwright:8002/health',
+      'http://trafilatura:8001/health',
+    ]);
+  });
+
+  it('marks an unreachable sidecar down and flips the top-level ok', async () => {
+    const fetch = fakeFetch((url) => {
+      if (url.includes('playwright')) throw new TypeError('fetch failed');
+      return reply();
+    });
+    const status = await createStatusChecker({ fetch, env: ENV })();
+
+    assert.equal(status.ok, false);
+    assert.deepEqual(status.services.playwright, { status: 'down', error: 'unreachable' });
+    assert.equal(status.services.trafilatura.status, 'ok');
+  });
+
+  it('distinguishes a timeout from an unreachable host', async () => {
+    const fetch = fakeFetch((url) => {
+      if (url.includes('playwright')) {
+        const err = new Error('The operation was aborted due to timeout');
+        err.name = 'TimeoutError';
+        throw err;
+      }
+      return reply();
+    });
+    const status = await createStatusChecker({ fetch, env: ENV })();
+
+    assert.equal(status.services.playwright.error, 'timeout');
+  });
+
+  it('reports a non-2xx health response with its status code', async () => {
+    const fetch = fakeFetch((url) => (url.includes('markitdown') ? reply({}, 502) : reply()));
+    const status = await createStatusChecker({ fetch, env: ENV })();
+
+    assert.equal(status.ok, false);
+    assert.equal(status.services.markitdown.status, 'down');
+    assert.equal(status.services.markitdown.error, 'http 502');
+  });
+
+  it('treats a 200 with ok:false as unhealthy', async () => {
+    // What a Playwright sidecar returns when the browser failed to launch.
+    const fetch = fakeFetch((url) =>
+      (url.includes('playwright') ? reply({ ok: false, browser: null }) : reply()));
+    const status = await createStatusChecker({ fetch, env: ENV })();
+
+    assert.equal(status.ok, false);
+    assert.equal(status.services.playwright.error, 'unhealthy');
+  });
+
+  it('accepts a 200 whose body is not JSON', async () => {
+    const fetch = fakeFetch(() => ({
+      ok: true,
+      status: 200,
+      json: async () => { throw new SyntaxError('Unexpected token'); },
+    }));
+    const status = await createStatusChecker({ fetch, env: ENV })();
+
+    assert.equal(status.ok, true);
+  });
+
+  it('calls an unconfigured sidecar not-configured and keeps ok true', async () => {
+    const fetch = fakeFetch(() => reply());
+    const status = await createStatusChecker({
+      fetch,
+      env: { TRAFILATURA_URL: ENV.TRAFILATURA_URL },
+    })();
+
+    assert.equal(status.ok, true);
+    assert.deepEqual(status.services.playwright, { status: 'not-configured' });
+    assert.deepEqual(status.services.markitdown, { status: 'not-configured' });
+    assert.equal(fetch.calls.length, 1);
+  });
+
+  it('reports a malformed sidecar URL as misconfigured', async () => {
+    const fetch = fakeFetch(() => reply());
+    const status = await createStatusChecker({
+      fetch,
+      env: { ...ENV, PLAYWRIGHT_URL: 'not a url' },
+    })();
+
+    assert.equal(status.ok, false);
+    assert.deepEqual(status.services.playwright, { status: 'down', error: 'misconfigured' });
+  });
+
+  it('never leaks the sidecar URL into the error field', async () => {
+    const fetch = fakeFetch(() => { throw new Error('getaddrinfo ENOTFOUND playwright'); });
+    const status = await createStatusChecker({ fetch, env: ENV })();
+
+    assert.equal(JSON.stringify(status).includes('playwright:8002'), false);
+    assert.equal(JSON.stringify(status).includes('ENOTFOUND'), false);
+  });
+
+  it('serves a second call from cache within the TTL', async () => {
+    const fetch = fakeFetch(() => reply());
+    let clock = 1000;
+    const check = createStatusChecker({ fetch, env: ENV, ttlMs: 5000, now: () => clock });
+
+    await check();
+    clock += 4999;
+    await check();
+
+    assert.equal(fetch.calls.length, 3, 'three sidecars probed exactly once');
+  });
+
+  it('re-probes once the TTL has expired', async () => {
+    const fetch = fakeFetch(() => reply());
+    let clock = 1000;
+    const check = createStatusChecker({ fetch, env: ENV, ttlMs: 5000, now: () => clock });
+
+    await check();
+    clock += 5001;
+    await check();
+
+    assert.equal(fetch.calls.length, 6);
+  });
+
+  it('coalesces concurrent calls into one round of probes', async () => {
+    let release;
+    const gate = new Promise((r) => { release = r; });
+    const fetch = fakeFetch(async () => { await gate; return reply(); });
+    const check = createStatusChecker({ fetch, env: ENV });
+
+    const both = Promise.all([check(), check()]);
+    release();
+    const [a, b] = await both;
+
+    assert.equal(fetch.calls.length, 3);
+    assert.deepEqual(a, b);
+  });
+
+  it('does not cache across a failed probe round', async () => {
+    let fail = true;
+    const fetch = fakeFetch(() => { if (fail) throw new TypeError('fetch failed'); return reply(); });
+    let clock = 1000;
+    const check = createStatusChecker({ fetch, env: ENV, ttlMs: 5000, now: () => clock });
+
+    assert.equal((await check()).ok, false);
+    fail = false;
+    clock += 5001;
+    assert.equal((await check()).ok, true);
+  });
+});


### PR DESCRIPTION
## v3.10.0 — recipe append blocks, sidecar health endpoint

Two independent features that accumulated on top of 3.9.0.

### `append`: pull numeric data out of SSR state blobs

Single-page frameworks serialize their initial state into a `<script>` block (`ng-state`, `__NEXT_DATA__`, …) and then render it as a chart. The numbers are in the HTML, but no CSS selector reaches them, so extraction returns prose and drops the data the page is actually about.

The new optional recipe field `append` names a script selector and a path into the JSON, optionally projects a subset of fields and caps the row count, and appends the result as a fenced JSON code block at the end of the document. Output size is capped, and the block is attached on every extraction path — but only after the render decision, so it cannot influence which extractor wins.

Deliberately not documented in `SITE-RECIPES.md`: this is an internal escape hatch for instance-local recipes, not a contributor-facing feature.

### `GET /api/status`: make a dead sidecar visible

The Playwright sidecar on the production instance crash-looped for eight weeks without anyone noticing. Nothing looked broken from outside — the service kept answering `200`, extraction just silently fell back to near-empty results for every page that needs a browser render.

```json
{"ok":false,"version":"3.10.0","services":{
  "trafilatura":{"status":"ok","latencyMs":3},
  "playwright":{"status":"down","error":"unreachable"},
  "markitdown":{"status":"not-configured"}}}
```

- Probes each configured sidecar's `/health` in parallel; `200` when they all answer, **`503`** as soon as one is down, so a plain HTTP monitor catches it without keyword matching.
- A sidecar that was never configured is `not-configured`, not a failure — running without Playwright or markitdown stays a supported setup.
- Error reasons are a closed vocabulary (`unreachable`, `timeout`, `unhealthy`, `http <code>`, `misconfigured`). The endpoint is public and a raw error message would carry the internal sidecar hostname; a test asserts that.
- Ungated like the other aggregate endpoints, because a monitor polls it without credentials. Results are cached 5 s and concurrent callers share one round of probes.

Also pins `playwright-stealth`, the one unpinned sidecar dependency, to the version already running in production.

### Verification

- `node --test`: **1251 pass**, 0 fail. `markitdown-sidecar/test_limits.py` + `test_youtube.py`: 13 pass.
- 22 new tests across `test/status.test.js` and `test/status-endpoint.test.js`.
- Live-verified on the production instance: `/api/status` returns `200` with all three sidecars healthy; the `503` path verified against a real server instance with unreachable sidecar URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018W84fQHmxwu4S519Zd4Vde
