### PR TITLE
fix(playwright): stop announcing the renderer as HeadlessChrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Self-hosters should consult [`MIGRATION.md`](./MIGRATION.md) when upgrading acro
      there at the same time, or this heading renders as literal bracketed
      text. -->
 
+---
+
+## [3.10.1] - 2026-08-27
+
 ### Fixed
 
 - **The Playwright sidecar no longer announces itself as an automation browser.** Chromium derives its `Sec-CH-UA` header from its own identity, and `new_context(user_agent=…)` does not touch it, so every rendered request went out claiming `Chrome/147` in the User-Agent and `"HeadlessChrome";v="131"` in the header directly below it. Hosts behind a bot manager read the second one: measured against an Akamai-protected site, holding every other header constant and swapping only that brand token was the entire difference between `403` and `200` — the page then returned 138k characters of article text instead of 283 characters of "Access Denied". The User-Agent pool was never the problem, and neither was the requesting IP. The sidecar now derives the Client-Hints metadata (brand, version, platform, mobile flag) from the User-Agent it actually sends, so the two agree. For a non-Chromium User-Agent — the iPhone profile behind `mobileUa` — it strips the `Sec-CH-UA*` headers instead, because Safari sends no Client Hints and inventing one would be a fresh contradiction. Both paths are best-effort: a failure is logged and the render proceeds. `playwright-stealth` does not cover this, since it patches JavaScript properties rather than request headers.
@@ -422,6 +426,7 @@ First public release. Self-hosted URL → Markdown service for humans and AI age
 
 ---
 
+[3.10.1]: https://github.com/AeternaLabsHQ/pullmd/releases/tag/v3.10.1
 [3.10.0]: https://github.com/AeternaLabsHQ/pullmd/releases/tag/v3.10.0
 [3.9.0]: https://github.com/AeternaLabsHQ/pullmd/releases/tag/v3.9.0
 [3.8.0]: https://github.com/AeternaLabsHQ/pullmd/releases/tag/v3.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Self-hosters should consult [`MIGRATION.md`](./MIGRATION.md) when upgrading acro
      there at the same time, or this heading renders as literal bracketed
      text. -->
 
+### Fixed
+
+- **The Playwright sidecar no longer announces itself as an automation browser.** Chromium derives its `Sec-CH-UA` header from its own identity, and `new_context(user_agent=…)` does not touch it, so every rendered request went out claiming `Chrome/147` in the User-Agent and `"HeadlessChrome";v="131"` in the header directly below it. Hosts behind a bot manager read the second one: measured against an Akamai-protected site, holding every other header constant and swapping only that brand token was the entire difference between `403` and `200` — the page then returned 138k characters of article text instead of 283 characters of "Access Denied". The User-Agent pool was never the problem, and neither was the requesting IP. The sidecar now derives the Client-Hints metadata (brand, version, platform, mobile flag) from the User-Agent it actually sends, so the two agree. For a non-Chromium User-Agent — the iPhone profile behind `mobileUa` — it strips the `Sec-CH-UA*` headers instead, because Safari sends no Client Hints and inventing one would be a fresh contradiction. Both paths are best-effort: a failure is logged and the render proceeds. `playwright-stealth` does not cover this, since it patches JavaScript properties rather than request headers.
+
 ---
 
 ## [3.10.0] - 2026-08-27

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pullmd",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pullmd",
-      "version": "3.10.0",
+      "version": "3.10.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pullmd",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "type": "module",
   "main": "server.js",
   "license": "AGPL-3.0-or-later",

--- a/playwright-sidecar/Dockerfile
+++ b/playwright-sidecar/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app.py .
+COPY app.py ua_metadata.py .
 
 USER app
 EXPOSE 8002

--- a/playwright-sidecar/README.md
+++ b/playwright-sidecar/README.md
@@ -35,6 +35,23 @@ networks:
     driver: bridge
 ```
 
+## Identity
+
+The rendered request has to be internally consistent. Chromium builds its
+`Sec-CH-UA` header from its own identity, and overriding the User-Agent on the
+browser context does not touch it — so by default a request goes out claiming
+`Chrome/147` in one header and `"HeadlessChrome";v="131"` in the next. Bot
+rules read the second one: holding everything else constant and swapping only
+that brand token is the difference between `200` and `403` on hosts behind a
+bot manager.
+
+The sidecar therefore rewrites the Client-Hints metadata to match the
+User-Agent it sends (brand, version, platform, mobile flag). For a
+non-Chromium User-Agent — the iPhone profile from `mobileUa` — it strips the
+`Sec-CH-UA*` headers instead, because Safari sends no Client Hints and a
+fabricated one would be a fresh contradiction. Both are best-effort: a failure
+here is logged and the render proceeds.
+
 ## Resource footprint
 
 - Image size: **~3.7 GB** (Microsoft Playwright base image bundles Chromium, Firefox, WebKit binaries)

--- a/playwright-sidecar/app.py
+++ b/playwright-sidecar/app.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel
 from playwright.async_api import async_playwright, TimeoutError as PWTimeout
 import importlib.metadata
 
+from ua_metadata import build_ua_metadata
+
 logging.basicConfig(level=logging.INFO)
 
 # Last updated: 2026-05-02
@@ -41,6 +43,40 @@ except (ImportError, AttributeError):
         async def _apply_stealth(page):
             pass
         log.warning("playwright-stealth not installed; running without bot-detection mitigation")
+
+
+async def _align_client_hints(context, page, user_agent: str, mobile: bool) -> None:
+    """Make Sec-CH-UA agree with the User-Agent we claim.
+
+    Chromium builds Sec-CH-UA from its own identity, so overriding the UA on
+    the context leaves the request advertising `"HeadlessChrome";v="<real>"`
+    one header below a UA that says Chrome. Bot rules key on exactly that:
+    with everything else held constant, only swapping that brand token decides
+    whether an Akamai-protected host answers 200 or 403.
+
+    Chromium-based UA -> rewrite the metadata to match. Anything else (the
+    iPhone/Safari device profile) -> drop the header, because Safari sends no
+    Client Hints and a fabricated one would be a fresh contradiction.
+
+    Best-effort throughout: this is camouflage, never a reason to fail a
+    render that would otherwise succeed.
+    """
+    metadata = build_ua_metadata(user_agent, mobile=mobile)
+
+    if metadata is None:
+        async def _strip(route):
+            headers = {k: v for k, v in route.request.headers.items()
+                       if not k.lower().startswith("sec-ch-ua")}
+            await route.continue_(headers=headers)
+        await page.route("**/*", _strip)
+        return
+
+    session = await context.new_cdp_session(page)
+    await session.send("Emulation.setUserAgentOverride", {
+        "userAgent": user_agent,
+        "platform": metadata["platform"],
+        "userAgentMetadata": metadata,
+    })
 
 
 @asynccontextmanager
@@ -81,20 +117,23 @@ async def _render(url: str, wait_for: str | None = None, wait_timeout_ms: int | 
         device = state["pw"].devices.get("iPhone 13")
         if device is None:
             # Fallback: hand-crafted mobile context if the device profile is unavailable
+            effective_ua = (
+                "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) "
+                "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+            )
             context = await state["browser"].new_context(
-                user_agent=(
-                    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) "
-                    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
-                ),
+                user_agent=effective_ua,
                 viewport={"width": 390, "height": 844},
                 device_scale_factor=3,
                 is_mobile=True,
                 has_touch=True,
             )
         else:
+            effective_ua = device.get("user_agent", "")
             context = await state["browser"].new_context(**device)
     else:
-        context = await state["browser"].new_context(user_agent=user_agent or USER_AGENT)
+        effective_ua = user_agent or USER_AGENT
+        context = await state["browser"].new_context(user_agent=effective_ua)
 
     try:
         page = await context.new_page()
@@ -102,6 +141,10 @@ async def _render(url: str, wait_for: str | None = None, wait_timeout_ms: int | 
             await _apply_stealth(page)
         except Exception as e:
             log.warning("stealth apply failed (non-fatal): %s", e)
+        try:
+            await _align_client_hints(context, page, effective_ua, mobile_ua)
+        except Exception as e:
+            log.warning("client-hints alignment failed (non-fatal): %s", e)
         await page.goto(url, wait_until="domcontentloaded", timeout=NAV_TIMEOUT_MS)
 
         if wait_for:

--- a/playwright-sidecar/test_ua_metadata.py
+++ b/playwright-sidecar/test_ua_metadata.py
@@ -1,0 +1,83 @@
+"""Standalone tests for the Client-Hints metadata helpers.
+
+No pytest / playwright dependency — run directly:  python3 test_ua_metadata.py
+Exits non-zero on the first failed assertion.
+"""
+from ua_metadata import build_ua_metadata, chrome_version, platform_for
+
+CHROME_WIN = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+              "(KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36")
+HEADLESS_LINUX = ("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                  "(KHTML, like Gecko) HeadlessChrome/131.0.6778.33 Safari/537.36")
+IPHONE_SAFARI = ("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) "
+                 "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1")
+ANDROID_CHROME = ("Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 "
+                  "(KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36")
+
+
+def test_chrome_version_extracted():
+    assert chrome_version(CHROME_WIN) == "147.0.0.0"
+    assert chrome_version(ANDROID_CHROME) == "131.0.0.0"
+
+
+def test_headless_chrome_is_still_chrome_like():
+    # We must recognise it precisely because this is the UA we have to fix up.
+    assert chrome_version(HEADLESS_LINUX) == "131.0.6778.33"
+
+
+def test_non_chromium_has_no_version():
+    assert chrome_version(IPHONE_SAFARI) is None
+    assert chrome_version("") is None
+    assert chrome_version("Mozilla/5.0 (X11; Linux) Gecko/20100101 Firefox/130.0") is None
+
+
+def test_platform_follows_the_ua():
+    assert platform_for(CHROME_WIN) == ("Windows", "10.0.0")
+    assert platform_for(HEADLESS_LINUX)[0] == "Linux"
+    assert platform_for(ANDROID_CHROME)[0] == "Android"
+    assert platform_for("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)")[0] == "macOS"
+
+
+def test_metadata_never_says_headless():
+    # The whole point: no brand may carry the automation token.
+    meta = build_ua_metadata(HEADLESS_LINUX)
+    brands = [b["brand"] for b in meta["brands"]]
+    assert "HeadlessChrome" not in brands, brands
+    assert "Google Chrome" in brands
+    assert "Chromium" in brands
+
+
+def test_brand_version_matches_the_ua_version():
+    meta = build_ua_metadata(CHROME_WIN)
+    for b in meta["brands"]:
+        if b["brand"] in ("Chromium", "Google Chrome"):
+            assert b["version"] == "147", b
+    assert meta["fullVersion"] == "147.0.0.0"
+
+
+def test_platform_matches_the_ua_platform():
+    # A Windows UA with a Linux platform hint is the same contradiction we set
+    # out to remove, just one field over.
+    meta = build_ua_metadata(CHROME_WIN)
+    assert meta["platform"] == "Windows"
+    assert meta["mobile"] is False
+    assert meta["architecture"] == "x86"
+
+
+def test_mobile_flag_from_ua_and_from_caller():
+    assert build_ua_metadata(ANDROID_CHROME)["mobile"] is True
+    assert build_ua_metadata(ANDROID_CHROME)["architecture"] == ""
+    assert build_ua_metadata(CHROME_WIN, mobile=True)["mobile"] is True
+
+
+def test_non_chromium_ua_gets_no_metadata():
+    # Safari sends no Sec-CH-UA at all; inventing one would be a new tell.
+    assert build_ua_metadata(IPHONE_SAFARI) is None
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for t in tests:
+        t()
+        print(f"ok - {t.__name__}")
+    print(f"\n{len(tests)} passed")

--- a/playwright-sidecar/ua_metadata.py
+++ b/playwright-sidecar/ua_metadata.py
@@ -1,0 +1,70 @@
+"""Client-Hints metadata derived from the User-Agent we claim to be.
+
+Chromium emits `Sec-CH-UA` itself, from the *browser's own* identity, and
+`new_context(user_agent=...)` does not touch it. So a request goes out with a
+User-Agent saying "Chrome/147 on Windows" and, one header down, a Sec-CH-UA
+saying `"HeadlessChrome";v="131"`. Bot rules read that second header: swapping
+only the brand token, with everything else identical, is the difference
+between 403 and 200 on an Akamai-protected host.
+
+These helpers turn the UA string we actually send into the Client-Hints
+metadata a real browser would send alongside it, so the two agree.
+"""
+import re
+
+# GREASE entry. Real Chrome randomises the label and its position; a fixed
+# plausible one is enough - what gets matched on is the presence of a real
+# browser brand, not the decoy.
+GREASE_BRAND = "Not_A Brand"
+GREASE_VERSION = "24"
+
+
+def chrome_version(user_agent: str) -> str | None:
+    """Full Chrome version from a UA string, or None if it is not Chrome-like.
+
+    Matches Chrome and HeadlessChrome; deliberately not Safari or Firefox,
+    which send no Client Hints at all.
+    """
+    m = re.search(r"(?:Headless)?Chrome/(\d+(?:\.\d+)*)", user_agent or "")
+    return m.group(1) if m else None
+
+
+def platform_for(user_agent: str) -> tuple[str, str]:
+    """(platform, platformVersion) as Client Hints spell them."""
+    ua = user_agent or ""
+    if "Android" in ua:
+        return "Android", "13.0.0"
+    if "Windows NT" in ua:
+        return "Windows", "10.0.0"
+    if "Mac OS X" in ua or "Macintosh" in ua:
+        return "macOS", "14.0.0"
+    if "CrOS" in ua:
+        return "Chrome OS", "14541.0.0"
+    return "Linux", ""
+
+
+def build_ua_metadata(user_agent: str, mobile: bool = False) -> dict | None:
+    """Client-Hints metadata matching `user_agent`, or None when it is not
+    a Chromium-based UA (Safari and friends send no Sec-CH-UA - for those the
+    caller has to strip the header instead of rewriting it)."""
+    full_version = chrome_version(user_agent)
+    if full_version is None:
+        return None
+
+    major = full_version.split(".")[0]
+    platform, platform_version = platform_for(user_agent)
+    is_mobile = mobile or "Mobile" in (user_agent or "") or "Android" in (user_agent or "")
+
+    return {
+        "brands": [
+            {"brand": GREASE_BRAND, "version": GREASE_VERSION},
+            {"brand": "Chromium", "version": major},
+            {"brand": "Google Chrome", "version": major},
+        ],
+        "fullVersion": full_version,
+        "platform": platform,
+        "platformVersion": platform_version,
+        "architecture": "" if is_mobile else "x86",
+        "model": "",
+        "mobile": is_mobile,
+    }


### PR DESCRIPTION
## The renderer was telling every site it was an automation browser

Chromium builds its `Sec-CH-UA` header from its **own** identity. `new_context(user_agent=…)` does not touch it. So every rendered request went out like this:

```
User-Agent: ... Chrome/147.0.0.0 ...          <- what we set
Sec-Ch-Ua:  "HeadlessChrome";v="131", ...     <- what Chromium sends
```

Bot managers read the second line.

### How the cause was isolated

Chromium's real header set was captured and replayed through curl against an Akamai-protected host, holding every other header constant:

| Request | Result |
|---|---|
| `Sec-Ch-Ua: "HeadlessChrome";v="131"` + UA `Chrome/131` | **403** |
| `Sec-Ch-Ua: "Google Chrome";v="131"` + UA `Chrome/131` | **200** |
| `Sec-Ch-Ua` omitted entirely | **200** |

Only the brand token differs between rows one and two, so the version mismatch (UA 147 vs hints 131) is not what was being matched on — the token `HeadlessChrome` is.

Ruled out along the way:
- **Not the User-Agent pool.** Passing the browser's own real UA instead of the override changed nothing; the hints still said `HeadlessChrome`.
- **Not the requesting IP.** The same address serves `200` as soon as the client identity is coherent.
- **Not `playwright-stealth`.** It patches JavaScript properties (`navigator.*`), not request headers.
- **Not fixable with `channel="chromium"`.** New headless drops the token but leaves a bare `"Chromium"` brand, still refused.

### The fix

`ua_metadata.build_ua_metadata()` derives Client-Hints metadata from the User-Agent the sidecar actually sends — brand, version, platform, mobile flag — and applies it via CDP `Emulation.setUserAgentOverride`, so the two headers agree.

A **non-Chromium** User-Agent (the iPhone profile behind `mobileUa`) takes the other branch: the `Sec-CH-UA*` headers are stripped, because Safari sends no Client Hints at all and fabricating one would just be a different contradiction.

Both paths are best-effort — a failure is logged and the render proceeds, since this is camouflage and never a reason to fail a render that would otherwise work.

`ua_metadata.py` is a separate module so the derivation is testable without a browser, and it is listed explicitly in the Dockerfile `COPY` line: a sidecar module missing from that line does not fail the build, it fails the container start.

### Verification

Deployed to the production instance and measured through the full pipeline:

| | before | after |
|---|---|---|
| status | 403 | 200 |
| extracted text | 283 chars ("Access Denied") | **138,661 chars** |
| `X-Quality` | 0 | **1** |
| `X-Source` | — | `playwright` |

Outgoing headers now read `Sec-Ch-Ua: "Not_A Brand";v="24", "Chromium";v="147", "Google Chrome";v="147"` with `Sec-Ch-Ua-Platform: "Windows"`, matching the `Chrome/147` User-Agent. The mobile profile sends no `Sec-CH-UA` at all, as Safari would not.

Regression-checked against two JS-rendered pages that already worked (`z.ai/blog`, `mathstodon.xyz`): both still render, 41 KB and 226 KB.

`python3 test_ua_metadata.py`: 9 passed. `node --test`: 1251 pass. Sidecar Python suites: 13 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018W84fQHmxwu4S519Zd4Vde
